### PR TITLE
fix: use admin PAT for semantic-release to push to protected main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,4 +27,4 @@ jobs:
 
       - run: npx semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
## Closes #N/A — CI hotfix

## Summary
Swaps `GITHUB_TOKEN` (the Actions bot, blocked by branch protection) for `RELEASE_TOKEN` (admin PAT) so semantic-release can push the changelog commit and version tag back to main.

## How to test
1. Merge and confirm the Release action completes without a push rejection.
