### PR TITLE
fix: revert to GITHUB_TOKEN for semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,4 +27,4 @@ jobs:
 
       - run: npx semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Reverts `RELEASE_TOKEN` back to `GITHUB_TOKEN` now that the PR requirement has been removed from branch protection. The local pre-push hook remains the human-facing guardrail against direct pushes to main.

## How to test
1. Merge and confirm the Release action completes successfully.
