### PR TITLE
feat: sharpen homepage positioning

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,24 @@ types/umami.d.ts        ← window.umami type declaration
 
 **GitHub:** https://github.com/josh-amptech/amptech-site
 
+## Codex + GitHub CLI
+
+Codex sandboxed shells do not reliably inherit or persist GitHub CLI auth. Attempts to
+bootstrap `GH_TOKEN`, PowerShell SecretStore, or other environment variables inside the
+sandbox may appear to work briefly and then fail with `HTTP 401`.
+
+When an agent needs `gh`, run it from the outside Windows context with escalated
+permissions instead of trying to repair sandbox auth:
+
+```powershell
+gh issue list --repo josh-amptech/amptech-site --state open
+gh issue view 13 --repo josh-amptech/amptech-site
+```
+
+For issue and PR reads, the GitHub connector is also acceptable when available. For
+GitHub writes, prefer the connector or an escalated Windows-context `gh` command, then
+verify the resulting issue/PR state.
+
 ## Brand
 
 Full brand guide: `docs/brand-guide.pdf` | Messaging guide: `AmpTech-Brand-Messaging-Guide-v2.docx`

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -5,7 +5,7 @@ import Button from "@/components/ui/Button";
 export const metadata = {
   title: "About — AmpTech",
   description:
-    "20+ years of engineering experience, now applied to helping entrepreneurs ship their ideas.",
+    "The senior engineering help behind AmpTech's prototype-to-product work.",
 };
 
 export default function AboutPage() {
@@ -16,26 +16,27 @@ export default function AboutPage() {
           About
         </p>
         <h1 className="display-type text-[3.5rem] leading-[0.92] text-brand-ink mb-6 sm:text-[4.7rem] md:text-[5.8rem]">
-          THE ENGINEER
+          THE HELP
           <br />
-          BEHIND YOUR
+          BEHIND THE
           <br />
-          IDEA.
+          BUILD.
         </h1>
         <p className="text-lg text-brand-gray leading-relaxed mb-6">
-          AmpTech was founded to solve a specific problem: too many good ideas
-          stall out in the gap between what AI tools promise and what
-          non-technical founders can actually ship on their own.
+          AmpTech was founded for the moment when a promising build stops
+          moving. The demo exists. The idea is still strong. But the project
+          needs experienced engineering to become something real users can rely
+          on.
         </p>
         <p className="text-base text-brand-gray leading-relaxed mb-6">
-          We work with founders who have momentum, clarity, and a real product
-          vision, but who need an experienced guide to turn that into something
-          they can launch and grow.
+          We work with founders and business owners who have momentum, clarity,
+          and a real product vision, but need help getting from rough version to
+          launch-ready software.
         </p>
         <p className="text-base text-brand-gray leading-relaxed mb-10">
-          AmpTech uses the best AI-powered development tools available, not to
-          replace engineering judgment, but to dramatically accelerate what good
-          engineering judgment can produce.
+          We use modern AI-assisted development tools where they help, but the
+          work is led by engineering judgment: architecture, tradeoffs,
+          debugging, deployment, and clean ownership.
         </p>
         <div className="border border-gray-200 p-8 mb-10">
           <p className="text-sm font-semibold uppercase tracking-widest text-brand-red mb-4">
@@ -47,8 +48,8 @@ export default function AboutPage() {
             have worked with us directly.
           </p>
           <p className="text-base text-brand-gray leading-relaxed">
-            The goal is simple: help you get from idea to real software without
-            having to become a developer yourself.
+            The goal is simple: help you get from stuck build to real software
+            without having to become a developer yourself.
           </p>
         </div>
         <div className="flex flex-wrap gap-3 mb-10">

--- a/app/globals.css
+++ b/app/globals.css
@@ -23,7 +23,6 @@ html {
 
 body {
   background:
-    radial-gradient(circle at top, rgba(212, 30, 16, 0.09), transparent 28%),
     linear-gradient(180deg, #f7f2ea 0%, #f7f3ee 42%, #ffffff 100%);
   color: #4D4D4D;
 }
@@ -48,16 +47,16 @@ a {
   z-index: -1;
   pointer-events: none;
   background:
-    linear-gradient(120deg, rgba(212, 30, 16, 0.08), transparent 22%),
-    radial-gradient(circle at 80% 18%, rgba(212, 30, 16, 0.09), transparent 18%);
-  opacity: 0.9;
+    linear-gradient(120deg, rgba(212, 30, 16, 0.055), transparent 28%),
+    linear-gradient(180deg, rgba(11, 11, 12, 0.04), transparent 34%);
+  opacity: 0.75;
 }
 
 .hero-noise {
   position: relative;
   overflow: clip;
   background:
-    linear-gradient(135deg, rgba(11, 11, 12, 0.97) 0%, rgba(24, 24, 27, 0.96) 54%, rgba(212, 30, 16, 0.92) 100%);
+    linear-gradient(135deg, rgba(11, 11, 12, 0.99) 0%, rgba(19, 19, 21, 0.98) 62%, rgba(96, 16, 12, 0.96) 100%);
 }
 
 .hero-noise::before {
@@ -75,12 +74,9 @@ a {
 .hero-noise::after {
   content: "";
   position: absolute;
-  inset: auto -12% -20% auto;
-  width: min(50vw, 38rem);
-  height: min(50vw, 38rem);
-  border-radius: 9999px;
-  background: radial-gradient(circle, rgba(241, 236, 228, 0.32), transparent 68%);
-  filter: blur(24px);
+  inset: auto 0 0 0;
+  height: 1px;
+  background: rgba(241, 236, 228, 0.28);
 }
 
 .section-rule {
@@ -90,7 +86,6 @@ a {
 @media (max-width: 768px) {
   body {
     background:
-      radial-gradient(circle at top, rgba(212, 30, 16, 0.08), transparent 22%),
       linear-gradient(180deg, #f7f2ea 0%, #ffffff 72%);
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,9 +17,9 @@ const montserrat = Montserrat({
 });
 
 export const metadata: Metadata = {
-  title: "AmpTech — Your App Idea, Finally Built",
+  title: "AmpTech — From Stuck Demo To Real Product",
   description:
-    "AmpTech builds professional web and mobile applications for entrepreneurs and business owners — AI-powered development speed, senior engineering quality.",
+    "AmpTech helps founders and business owners turn rough prototypes, stalled AI builds, and app ideas into software people can actually use.",
 };
 
 export default function RootLayout({

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -4,25 +4,25 @@ import Button from "@/components/ui/Button";
 export const metadata = {
   title: "Services — AmpTech",
   description:
-    "What AmpTech builds, how it works, and what it costs.",
+    "How AmpTech turns rough prototypes, stalled builds, and app ideas into software people can use.",
 };
 
 const serviceAreas = [
   {
     title: "Product builds",
-    body: "New web and mobile applications for founders who need a real product, not a half-working prototype.",
+    body: "New web and mobile applications for founders who need more than a demo.",
   },
   {
     title: "Rescue and rebuild work",
-    body: "Projects that got stuck in Replit, Bolt, Lovable, Cursor, or with a freelancer and need experienced hands to get to production.",
+    body: "Projects that got stuck in Replit, Bolt, Lovable, Cursor, or with a freelancer and need a clear path to launch.",
   },
   {
     title: "Scoping and technical direction",
-    body: "Architecture, build plans, implementation decisions, and the judgment to kill bad paths before they become expensive.",
+    body: "Architecture, build plans, implementation decisions, and the judgment to stop bad paths before they get expensive.",
   },
   {
     title: "Post-launch iteration",
-    body: "Ongoing maintenance and product improvement for teams that want a long-term engineering partner after launch.",
+    body: "Ongoing product improvement for teams that want a steady engineering partner after launch.",
   },
 ];
 
@@ -34,16 +34,16 @@ export default function ServicesPage() {
           Services
         </p>
         <h1 className="display-type max-w-4xl text-[3.5rem] leading-[0.92] text-brand-ink sm:text-[4.7rem] md:text-[5.8rem]">
-          FROM IDEA
+          FROM STUCK
           <br />
-          TO PRODUCT,
+          TO SHIPPED,
           <br />
           DONE RIGHT.
         </h1>
         <p className="mt-6 max-w-3xl text-lg leading-relaxed text-brand-gray">
-          AmpTech helps entrepreneurs and business owners turn app ideas into
-          working software. We use AI to accelerate delivery and engineering
-          judgment to make sure the result holds up under real use.
+          AmpTech helps founders and business owners turn rough prototypes,
+          stalled AI builds, and app ideas into software that holds up under
+          real use.
         </p>
 
         <div className="mt-16 grid gap-5 border-t border-black/10 pt-8 md:grid-cols-2">
@@ -65,15 +65,15 @@ export default function ServicesPage() {
           </p>
           <div className="max-w-3xl space-y-4 text-base leading-relaxed text-brand-gray">
             <p>
-              Every engagement starts with a free discovery call. If the build
-              is a fit, the next step is scoped planning so you know what we are
-              building, how long it should take, and what it will cost before
-              development begins.
+              Every engagement starts with a discovery call. If the build is a
+              fit, the next step is scoped planning so you know what can be
+              kept, what needs work, how long it should take, and what it will
+              cost before development begins.
             </p>
             <p>
-              AmpTech bills hourly against a scoped plan. The point is not the
-              billing model. The point is that you know what is happening before
-              the work starts and as it moves forward.
+              AmpTech bills hourly against a scoped plan. The point is
+              visibility: you know what is happening before the work starts and
+              as it moves forward.
             </p>
           </div>
         </div>
@@ -83,7 +83,7 @@ export default function ServicesPage() {
             Book A Discovery Call
           </Button>
           <Button href="/work" variant="secondary">
-            See Why Clients Hire Us
+            See The Proof
           </Button>
         </div>
       </div>

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -2,9 +2,9 @@ import SectionWrapper from "@/components/ui/SectionWrapper";
 import Button from "@/components/ui/Button";
 
 export const metadata = {
-  title: "Experience — AmpTech",
+  title: "Proof — AmpTech",
   description:
-    "How AmpTech establishes credibility before formal case studies exist.",
+    "How AmpTech shows its work before formal case studies exist.",
 };
 
 const proofBlocks = [
@@ -23,21 +23,21 @@ export default function WorkPage() {
     <SectionWrapper>
       <div className="max-w-5xl">
         <p className="mb-4 text-sm font-semibold uppercase tracking-[0.24em] text-brand-red">
-          Why Clients Hire AmpTech
+          Proof Of Work
         </p>
         <h1 className="display-type max-w-4xl text-[3.5rem] leading-[0.92] text-brand-ink sm:text-[4.7rem] md:text-[5.8rem]">
-          WHAT YOU
+          HOW TO
           <br />
-          SHOULD LOOK
+          TELL IF
           <br />
-          FOR IN
+          THE BUILD
           <br />
-          A GUIDE.
+          CAN WORK.
         </h1>
         <p className="mt-6 max-w-3xl text-lg leading-relaxed text-brand-gray">
           If you are deciding whether AmpTech is the right fit, start here. The
-          right guide should bring engineering experience, clear thinking, and
-          a process that makes you more confident, not more confused.
+          right partner should make the project clearer before they ask you to
+          commit to the build.
         </p>
 
         <div className="mt-16 grid gap-5 border-t border-black/10 pt-8 md:grid-cols-2">
@@ -59,9 +59,9 @@ export default function WorkPage() {
           </p>
           <div className="max-w-3xl space-y-4 text-base leading-relaxed text-brand-gray">
             <p>
-              You should know how the project will be scoped, what the tradeoffs
-              are, and who is making the technical decisions before development
-              begins.
+              You should know what can be kept, what needs rebuilding, what the
+              tradeoffs are, and who is making the technical decisions before
+              development begins.
             </p>
             <p>
               You should leave with the code, the infrastructure, and the

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -32,7 +32,7 @@ export default function Footer() {
               href="/work"
               className="text-sm text-gray-400 hover:text-white transition-colors"
             >
-              Experience
+              Proof
             </Link>
             <Link
               href="/about"

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -15,7 +15,9 @@ export default function Footer() {
               height={174}
               className="h-7 w-auto brightness-0 invert"
             />
-            <p className="text-sm text-gray-400 mt-2">Your idea, engineered.</p>
+            <p className="text-sm text-gray-400 mt-2">
+              From stuck prototype to real product.
+            </p>
           </div>
 
           {/* Links */}

--- a/components/layout/Nav.tsx
+++ b/components/layout/Nav.tsx
@@ -34,7 +34,7 @@ export default function Nav() {
               href="/work"
               className="text-sm font-medium text-white/72 transition-colors hover:text-white"
             >
-              Experience
+              Proof
             </Link>
             <Link
               href="/about"
@@ -85,7 +85,7 @@ export default function Nav() {
                 className="text-sm font-medium text-white/72"
                 onClick={() => setMenuOpen(false)}
               >
-                Experience
+                Proof
               </Link>
               <Link
                 href="/about"

--- a/components/sections/ClosingCTA.tsx
+++ b/components/sections/ClosingCTA.tsx
@@ -8,7 +8,7 @@ export default function ClosingCTA() {
     <section className="bg-brand-night px-4 py-28 sm:px-6 lg:px-8">
       <div className="mx-auto max-w-6xl">
         <motion.div
-          initial={{ opacity: 0, y: 24 }}
+          initial={false}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.6, ease: "easeOut" }}

--- a/components/sections/ClosingCTA.tsx
+++ b/components/sections/ClosingCTA.tsx
@@ -18,17 +18,17 @@ export default function ClosingCTA() {
             Ready To Build
           </p>
           <h2 className="display-type mb-6 text-[3.7rem] leading-[0.92] text-white sm:text-[5rem] md:text-[6.4rem]">
-            YOUR IDEA
+            READY TO
             <br />
-            HAS BEEN
+            GET THIS
             <br />
-            WAITING
+            ACROSS
             <br />
-            LONG ENOUGH.
+            THE LINE?
           </h2>
           <p className="mb-12 max-w-2xl text-lg leading-relaxed text-gray-300">
-            You do not need to figure this out alone. If you are ready to turn
-            the idea into a real product, let&apos;s talk.
+            Bring the rough build, the stuck prototype, or the idea you cannot
+            stop thinking about. We will help you find the next real step.
           </p>
           <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center">
             <Button

--- a/components/sections/Guide.tsx
+++ b/components/sections/Guide.tsx
@@ -26,7 +26,7 @@ export default function Guide() {
   return (
     <SectionWrapper className="bg-brand-gray-bg">
       <motion.div
-        initial={{ opacity: 0, y: 24 }}
+        initial={false}
         whileInView={{ opacity: 1, y: 0 }}
         viewport={{ once: true }}
         transition={{ duration: 0.6, ease: "easeOut" }}
@@ -62,7 +62,7 @@ export default function Guide() {
           {features.map((feature, i) => (
             <motion.div
               key={feature.title}
-              initial={{ opacity: 0, y: 20 }}
+              initial={false}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ duration: 0.5, delay: i * 0.08, ease: "easeOut" }}

--- a/components/sections/Guide.tsx
+++ b/components/sections/Guide.tsx
@@ -5,20 +5,20 @@ import SectionWrapper from "@/components/ui/SectionWrapper";
 
 const features = [
   {
-    title: "Senior engineering judgment",
-    description: "We know where AI helps, where it drifts, and what has to be right before real users ever see it.",
+    title: "Find the real blockers",
+    description: "We separate surface bugs from architecture problems so the project stops moving in circles.",
   },
   {
-    title: "AI speed, used well",
-    description: "We use the same tools creating all the momentum, but with the experience to turn that speed into a real product.",
+    title: "Build what has to hold",
+    description: "Accounts, data, payments, permissions, deployment, and the unglamorous parts that make software usable.",
   },
   {
-    title: "Transparent scoping",
-    description: "You know what we are building, how we will approach it, and what the next milestone looks like before work starts.",
+    title: "Keep the path visible",
+    description: "You know what is being fixed, what is being rebuilt, and what needs to happen before launch.",
   },
   {
-    title: "A clean handoff",
-    description: "You own the code, the infrastructure, and the documentation. No lock-in. No mystery.",
+    title: "Hand it over cleanly",
+    description: "The code, infrastructure, and documentation belong to you. No lock-in. No mystery build.",
   },
 ];
 
@@ -38,24 +38,22 @@ export default function Guide() {
         <div className="grid gap-12 border-t border-black/10 pt-10 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
           <div>
             <p className="display-type max-w-3xl text-[3.3rem] leading-[0.92] text-brand-ink sm:text-[4.4rem] md:text-[5.5rem]">
-              YOU DO NOT
-              <br />
-              NEED MORE
-              <br />
-              CODE.
-              <br />
               YOU NEED
               <br />
-              A GUIDE.
+              SOMEONE WHO
+              <br />
+              CAN GET IT
+              <br />
+              ACROSS
+              <br />
+              THE LINE.
             </p>
           </div>
           <div>
             <p className="text-lg leading-relaxed text-brand-gray">
-              AmpTech exists to close the gap between what AI tools promise and
-              what founders can actually ship on their own. We bring 20+ years
-              of professional software development experience to the part that
-              still requires judgment: architecture, tradeoffs, debugging, and
-              getting the product over the line.
+              AmpTech brings senior engineering judgment to the messy middle of
+              a build: the point where a prototype exists, but the product is
+              not stable enough to sell, demo, or depend on.
             </p>
           </div>
         </div>

--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -4,9 +4,9 @@ import { motion } from "framer-motion";
 import Button from "@/components/ui/Button";
 
 const capabilityMarks = [
-  "Built in weeks, not months",
-  "20+ years of engineering experience",
-  "You own the code. Always.",
+  "Stalled AI builds",
+  "Founder-led products",
+  "Launch-ready handoff",
 ];
 
 export default function Hero() {
@@ -39,26 +39,26 @@ export default function Hero() {
             initial={{ opacity: 0, y: 24 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.75, delay: 0.12, ease: "easeOut" }}
-            className="display-type max-w-4xl text-[4.1rem] leading-[0.88] text-brand-cream sm:text-[6.4rem] md:text-[8.8rem] lg:text-[10rem]"
+            className="display-type max-w-4xl text-[4rem] leading-[0.9] text-brand-cream sm:text-[6rem] md:text-[7.8rem] lg:text-[8.8rem]"
           >
-            YOUR APP
+            YOU HAVE
             <br />
-            IDEA,
+            A DEMO.
             <br />
-            <span className="text-brand-red-light">FINALLY</span>
+            NOW BUILD
             <br />
-            BUILT.
+            <span className="text-brand-red-light">THE PRODUCT.</span>
           </motion.h1>
 
           <motion.p
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6, delay: 0.22, ease: "easeOut" }}
-            className="mt-6 max-w-xl text-base leading-relaxed text-brand-cream/78 sm:text-lg"
+            className="mt-6 max-w-2xl text-base leading-relaxed text-brand-cream/82 sm:text-lg"
           >
-            AmpTech helps entrepreneurs and business owners turn app ideas into
-            real, working software, using AI to move fast and 20+ years of
-            engineering experience to build it right.
+            AmpTech helps founders and business owners turn promising AI builds,
+            rough prototypes, and half-finished app ideas into software people
+            can actually use.
           </motion.p>
 
           <motion.div
@@ -77,11 +77,11 @@ export default function Hero() {
               Book A Discovery Call
             </Button>
             <Button
-              href="/services"
+              href="/work"
               variant="secondary"
               className="border-white/50 text-white hover:bg-white hover:text-brand-night"
             >
-              See How It Works
+              See The Proof
             </Button>
           </motion.div>
 
@@ -107,7 +107,7 @@ export default function Hero() {
           >
             <div className="w-full border-t border-white/18 pt-6">
               <p className="text-xs uppercase tracking-[0.24em] text-brand-cream/52">
-                You do not need to become a developer to get this built.
+                You do not need another prompt. You need a build that holds up.
               </p>
             </div>
           </motion.div>
@@ -122,18 +122,18 @@ export default function Hero() {
           <div className="relative w-full max-w-md">
             <div className="absolute inset-x-0 top-10 h-px bg-white/18" />
             <div className="ml-auto w-[88%]">
-              <div className="display-type text-right text-[9rem] leading-[0.82] text-brand-cream/14">
-                20+
+              <div className="display-type text-right text-[8.4rem] leading-[0.82] text-brand-cream/14">
+                DEMO
                 <br />
-                YEARS
+                PRODUCT
               </div>
               <div className="-mt-4 border-l border-white/18 pl-6">
                 <p className="text-sm uppercase tracking-[0.24em] text-brand-cream/48">
-                  Built with AI speed.
+                  The hard part starts after the demo works.
                 </p>
                 <p className="mt-3 max-w-xs text-lg leading-relaxed text-brand-cream/78">
-                  Guided by the engineering judgment that keeps the foundation
-                  solid when real users show up.
+                  We turn the rough version into the version you can show,
+                  launch, own, and keep improving.
                 </p>
               </div>
             </div>

--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -14,13 +14,13 @@ export default function Hero() {
     <section className="hero-noise min-h-[calc(100svh-4rem)] text-white">
       <div className="mx-auto grid min-h-[calc(100svh-4rem)] max-w-7xl px-4 sm:px-6 lg:grid-cols-[minmax(0,1.2fr)_minmax(19rem,0.8fr)] lg:px-8">
         <motion.div
-          initial={{ opacity: 0, y: 24 }}
+          initial={false}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.75, ease: "easeOut" }}
           className="relative z-10 flex flex-col justify-center py-14 sm:py-18 lg:py-24"
         >
           <motion.p
-            initial={{ opacity: 0, y: 16 }}
+            initial={false}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.55, delay: 0.05, ease: "easeOut" }}
             className="mb-6 text-sm font-semibold uppercase tracking-[0.28em] text-brand-cream/70"
@@ -29,17 +29,17 @@ export default function Hero() {
           </motion.p>
 
           <motion.div
-            initial={{ scaleX: 0 }}
+            initial={false}
             animate={{ scaleX: 1 }}
             transition={{ duration: 0.55, ease: "easeOut", delay: 0.1 }}
             className="mb-8 h-px w-24 origin-left bg-brand-cream/40"
           />
 
           <motion.h1
-            initial={{ opacity: 0, y: 24 }}
+            initial={false}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.75, delay: 0.12, ease: "easeOut" }}
-            className="display-type max-w-4xl text-[4rem] leading-[0.9] text-brand-cream sm:text-[6rem] md:text-[7.8rem] lg:text-[8.8rem]"
+            className="display-type max-w-4xl text-[3.35rem] leading-[0.9] text-brand-cream sm:text-[6rem] md:text-[7.8rem] lg:text-[8.8rem]"
           >
             YOU HAVE
             <br />
@@ -51,7 +51,7 @@ export default function Hero() {
           </motion.h1>
 
           <motion.p
-            initial={{ opacity: 0, y: 20 }}
+            initial={false}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6, delay: 0.22, ease: "easeOut" }}
             className="mt-6 max-w-2xl text-base leading-relaxed text-brand-cream/82 sm:text-lg"
@@ -62,7 +62,7 @@ export default function Hero() {
           </motion.p>
 
           <motion.div
-            initial={{ opacity: 0, y: 18 }}
+            initial={false}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6, delay: 0.3, ease: "easeOut" }}
             className="mt-10 flex flex-col gap-4 sm:flex-row"
@@ -86,7 +86,7 @@ export default function Hero() {
           </motion.div>
 
           <motion.div
-            initial={{ opacity: 0, y: 8 }}
+            initial={false}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.55, delay: 0.38, ease: "easeOut" }}
             className="mt-8 grid gap-3 text-xs uppercase tracking-[0.22em] text-brand-cream/60 sm:mt-10 sm:flex sm:flex-wrap sm:gap-5 sm:text-sm"
@@ -100,7 +100,7 @@ export default function Hero() {
           </motion.div>
 
           <motion.div
-            initial={{ opacity: 0, x: 24 }}
+            initial={false}
             animate={{ opacity: 1, x: 0 }}
             transition={{ duration: 0.75, delay: 0.2, ease: "easeOut" }}
             className="mt-16 flex items-end lg:hidden"
@@ -114,7 +114,7 @@ export default function Hero() {
         </motion.div>
 
         <motion.div
-          initial={{ opacity: 0, x: 40 }}
+          initial={false}
           animate={{ opacity: 1, x: 0 }}
           transition={{ duration: 0.85, delay: 0.22, ease: "easeOut" }}
           className="relative hidden lg:flex lg:items-end lg:justify-end lg:py-24"

--- a/components/sections/Plan.tsx
+++ b/components/sections/Plan.tsx
@@ -6,18 +6,18 @@ import SectionWrapper from "@/components/ui/SectionWrapper";
 const steps = [
   {
     number: "01",
-    title: "Tell us what you want to build",
-    body: "Book a free 30-minute discovery call. Describe your idea without translating it into developer language first.",
+    title: "Show us where it stands",
+    body: "Bring the idea, prototype, repo, screenshots, or rough build. We will meet you where the project is.",
   },
   {
     number: "02",
-    title: "We scope, design, and price it",
-    body: "You get a build plan with real tradeoffs, timeline expectations, and cost before development starts.",
+    title: "Get a clear build plan",
+    body: "We identify what can be kept, what needs rebuilding, what it will take, and what should happen first.",
   },
   {
     number: "03",
-    title: "We build it and hand it over",
-    body: "You get tested software, deployment support, and ownership of the result instead of dependency on the process.",
+    title: "Launch with ownership",
+    body: "You get working software, deployment support, documentation, and the code in your hands.",
   },
 ];
 
@@ -34,11 +34,11 @@ export default function Plan() {
           The Plan
         </p>
         <h2 className="display-type mb-14 max-w-4xl text-[3.3rem] leading-[0.92] text-brand-cream sm:text-[4.4rem] md:text-[5.4rem]">
-          A CLEAR PATH
+          A SIMPLE PATH
           <br />
-          FROM IDEA
+          FROM STUCK
           <br />
-          TO LAUNCH.
+          TO SHIPPED.
         </h2>
 
         <div className="grid gap-10 border-t border-white/14 pt-10 md:grid-cols-3 md:gap-8">

--- a/components/sections/Plan.tsx
+++ b/components/sections/Plan.tsx
@@ -25,7 +25,7 @@ export default function Plan() {
   return (
     <SectionWrapper className="bg-brand-night text-white">
       <motion.div
-        initial={{ opacity: 0, y: 24 }}
+        initial={false}
         whileInView={{ opacity: 1, y: 0 }}
         viewport={{ once: true }}
         transition={{ duration: 0.6, ease: "easeOut" }}
@@ -45,7 +45,7 @@ export default function Plan() {
           {steps.map((step, i) => (
             <motion.div
               key={step.number}
-              initial={{ opacity: 0, y: 20 }}
+              initial={false}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ duration: 0.5, delay: i * 0.12, ease: "easeOut" }}

--- a/components/sections/Problem.tsx
+++ b/components/sections/Problem.tsx
@@ -7,7 +7,7 @@ export default function Problem() {
     <section className="px-4 py-24 sm:px-6 lg:px-8">
       <div className="mx-auto max-w-6xl">
         <motion.div
-          initial={{ opacity: 0, y: 24 }}
+          initial={false}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.6, ease: "easeOut" }}

--- a/components/sections/Problem.tsx
+++ b/components/sections/Problem.tsx
@@ -19,31 +19,29 @@ export default function Problem() {
           <div className="section-rule grid gap-12 pt-10 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)]">
             <div className="max-w-3xl">
               <p className="display-type text-[3.7rem] leading-[0.92] text-brand-ink sm:text-[5rem] md:text-[6.4rem]">
-                YOU GOT
+                THE DEMO
                 <br />
-                FURTHER
+                WORKED.
                 <br />
-                THAN YOU
+                THEN REALITY
                 <br />
-                EXPECTED.
+                SHOWED UP.
               </p>
             </div>
 
             <div className="space-y-6 pt-2">
               <p className="text-lg leading-relaxed text-brand-gray">
-                You&apos;ve seen what AI can build. You may have even tried
-                Replit, Bolt, Lovable, Claude, or Cursor yourself and gotten
-                further than you expected.
+                You got a screen on the page. Maybe a workflow clicked through.
+                Maybe it even felt like the product was almost there.
               </p>
               <p className="text-lg leading-relaxed text-brand-gray">
-                Then you hit the wall. The code broke in ways you could not
-                debug. The AI went in circles. The freelancer got you part of
-                the way there, but not all the way to something you could
-                launch with confidence.
+                Then the hidden work started. Authentication broke. Data did
+                not save cleanly. Edge cases piled up. The AI kept changing the
+                same files and the project stopped getting closer to launch.
               </p>
               <p className="text-sm uppercase tracking-[0.24em] text-brand-steel">
-                The gap between a promising demo and production-ready software
-                is real.
+                The gap between promising and launch-ready is where most builds
+                stall.
               </p>
             </div>
           </div>

--- a/components/sections/SocialProof.tsx
+++ b/components/sections/SocialProof.tsx
@@ -5,9 +5,9 @@ import SectionWrapper from "@/components/ui/SectionWrapper";
 import Button from "@/components/ui/Button";
 
 const proofPoints = [
-  "20+ years of professional software development experience",
+  "20+ years building software beyond the prototype stage",
   "References from people who have worked with us directly",
-  "A straightforward scoping process before full development begins",
+  "A scoping process that tells you what is real before you commit",
 ];
 
 export default function SocialProof() {
@@ -25,13 +25,12 @@ export default function SocialProof() {
               Confidence
             </p>
             <h2 className="display-type mb-4 text-[3rem] leading-[0.92] text-brand-ink sm:text-[3.9rem] md:text-[4.6rem]">
-              Built on experience, not hype.
+              Proof before promises.
             </h2>
             <p className="text-lg leading-relaxed text-brand-gray">
-              When you hire AmpTech, you are not hiring a prompt and hoping for
-              the best. You are hiring engineering judgment, clear
-              communication, and a process designed to get your idea to a real
-              launch.
+              You should not have to trust a big claim on a small website. You
+              should be able to see how we think, how we scope, and what kind
+              of work we can carry across the finish line.
             </p>
             <div className="mt-10 space-y-5 border-t border-black/10 pt-6">
               {proofPoints.map((point) => (
@@ -46,13 +45,13 @@ export default function SocialProof() {
           </div>
           <div className="flex-shrink-0">
             <Button
-              href="/about"
+              href="/work"
               variant="secondary"
               className="border-brand-ink text-brand-ink hover:bg-brand-ink"
               data-umami-event="cta-click"
               data-umami-event-label="experience-proof"
             >
-              Meet AmpTech
+              See The Proof
             </Button>
           </div>
         </div>

--- a/components/sections/SocialProof.tsx
+++ b/components/sections/SocialProof.tsx
@@ -14,7 +14,7 @@ export default function SocialProof() {
   return (
     <SectionWrapper>
       <motion.div
-        initial={{ opacity: 0, y: 24 }}
+        initial={false}
         whileInView={{ opacity: 1, y: 0 }}
         viewport={{ once: true }}
         transition={{ duration: 0.6, ease: "easeOut" }}

--- a/components/sections/Success.tsx
+++ b/components/sections/Success.tsx
@@ -5,20 +5,20 @@ import SectionWrapper from "@/components/ui/SectionWrapper";
 
 const outcomes = [
   {
-    headline: "A product you are proud to show people.",
-    body: "Not a prototype, not an MVP with 20 caveats.",
+    headline: "A product you can put in front of people.",
+    body: "Not a demo that only works when everything goes exactly right.",
   },
   {
-    headline: "A faster path to launch.",
-    body: "Built in weeks, not months, without sacrificing the foundation underneath it.",
+    headline: "A build that stops drifting.",
+    body: "Clear priorities, fewer loops, and progress you can actually measure.",
   },
   {
-    headline: "No lock-in. No dependency. No rug to pull.",
+    headline: "Ownership without a trap door.",
     body: "The code is yours. The infrastructure is yours. The direction is clear.",
   },
   {
-    headline: "Something you can actually run and grow.",
-    body: "Documented, handed over cleanly, and built to keep moving after launch.",
+    headline: "Something you can keep improving.",
+    body: "Documented, handed over cleanly, and built to move after launch.",
   },
 ];
 
@@ -56,13 +56,13 @@ export default function Success() {
           Success
         </p>
         <h2 className="display-type mb-14 max-w-4xl text-[3.3rem] leading-[0.92] text-brand-ink sm:text-[4.3rem] md:text-[5.2rem]">
-          WHAT SUCCESS
+          WHAT CHANGES
           <br />
-          LOOKS LIKE
+          WHEN THE
           <br />
-          ON THE OTHER
+          PRODUCT IS
           <br />
-          SIDE.
+          REAL.
         </h2>
 
         <div className="grid gap-8 border-t border-black/10 pt-10 sm:grid-cols-2">

--- a/components/sections/Success.tsx
+++ b/components/sections/Success.tsx
@@ -47,7 +47,7 @@ export default function Success() {
   return (
     <SectionWrapper>
       <motion.div
-        initial={{ opacity: 0, y: 24 }}
+        initial={false}
         whileInView={{ opacity: 1, y: 0 }}
         viewport={{ once: true }}
         transition={{ duration: 0.6, ease: "easeOut" }}
@@ -69,7 +69,7 @@ export default function Success() {
           {outcomes.map((item, i) => (
             <motion.div
               key={item.headline}
-              initial={{ opacity: 0, y: 16 }}
+              initial={false}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ duration: 0.5, delay: i * 0.1, ease: "easeOut" }}


### PR DESCRIPTION
## Closes #13

## Summary
Repositions the site around the founder-first, stalled-AI-build audience (decision recorded in #13's grooming comment):

- Reframe the homepage around the stuck demo / rough prototype → real product story ("YOU HAVE A DEMO. NOW BUILD THE PRODUCT.")
- Align Services, About, Proof, nav, footer, and metadata with the new positioning
- Keep homepage content visible before hydration (follow-up fix)
- Add Codex guidance for GitHub CLI sandbox/auth behavior

## Spec Checklist
- [x] All **Rules** from the linked story are implemented — audience fit is explicit (founder-first), project-type ambiguity reduced, single "Book A Discovery Call" CTA flow preserved
- [ ] **Examples** (scenarios) have been manually verified — copy reviewed against the rules in the 2026-06-11 StoryBrand audit; do one visual pass before merge
- [x] All **Questions** from the story are resolved or explicitly deferred — decisions recorded on #13 (founder-first; no broader segments; exclusions implicit via sharp positioning)
- [x] Implementation stays within the story's defined **Out of Scope** — no new service lines, no IA changes, no audience landing pages

## How to test
1. `npm run dev` → http://localhost:3000
2. Read the hero and first two sections as a founder with a stalled AI build — you should self-identify immediately; as a website-refresh buyer you should self-select out
3. Verify "Book A Discovery Call" works from nav, hero, and closing CTA; "See The Proof" routes to /work
4. Hard-refresh with JS disabled/throttled — homepage content should be visible before hydration
5. `npx tsc --noEmit` (already verified)

## Follow-ups (already groomed, Ready)
- #20 — rename "Proof" nav/CTAs (gates #19)
- #19 — full-site StoryBrand voice pass on top of this positioning

🤖 Generated with [Claude Code](https://claude.com/claude-code)
