### PR TITLE
feat: rename Proof nav and CTAs to How We Work

### DIFF
--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -83,7 +83,7 @@ export default function ServicesPage() {
             Book A Discovery Call
           </Button>
           <Button href="/work" variant="secondary">
-            See The Proof
+            See How We Work
           </Button>
         </div>
       </div>

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -2,9 +2,9 @@ import SectionWrapper from "@/components/ui/SectionWrapper";
 import Button from "@/components/ui/Button";
 
 export const metadata = {
-  title: "Proof — AmpTech",
+  title: "How We Work — AmpTech",
   description:
-    "How AmpTech shows its work before formal case studies exist.",
+    "How AmpTech scopes builds, makes technical decisions, and hands off working software.",
 };
 
 const proofBlocks = [
@@ -23,7 +23,7 @@ export default function WorkPage() {
     <SectionWrapper>
       <div className="max-w-5xl">
         <p className="mb-4 text-sm font-semibold uppercase tracking-[0.24em] text-brand-red">
-          Proof Of Work
+          How We Work
         </p>
         <h1 className="display-type max-w-4xl text-[3.5rem] leading-[0.92] text-brand-ink sm:text-[4.7rem] md:text-[5.8rem]">
           HOW TO

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -32,7 +32,7 @@ export default function Footer() {
               href="/work"
               className="text-sm text-gray-400 hover:text-white transition-colors"
             >
-              Proof
+              How We Work
             </Link>
             <Link
               href="/about"

--- a/components/layout/Nav.tsx
+++ b/components/layout/Nav.tsx
@@ -34,7 +34,7 @@ export default function Nav() {
               href="/work"
               className="text-sm font-medium text-white/72 transition-colors hover:text-white"
             >
-              Proof
+              How We Work
             </Link>
             <Link
               href="/about"
@@ -85,7 +85,7 @@ export default function Nav() {
                 className="text-sm font-medium text-white/72"
                 onClick={() => setMenuOpen(false)}
               >
-                Proof
+                How We Work
               </Link>
               <Link
                 href="/about"

--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -81,7 +81,7 @@ export default function Hero() {
               variant="secondary"
               className="border-white/50 text-white hover:bg-white hover:text-brand-night"
             >
-              See The Proof
+              See How We Work
             </Button>
           </motion.div>
 

--- a/components/sections/SocialProof.tsx
+++ b/components/sections/SocialProof.tsx
@@ -25,7 +25,7 @@ export default function SocialProof() {
               Confidence
             </p>
             <h2 className="display-type mb-4 text-[3rem] leading-[0.92] text-brand-ink sm:text-[3.9rem] md:text-[4.6rem]">
-              Proof before promises.
+              Look before you book.
             </h2>
             <p className="text-lg leading-relaxed text-brand-gray">
               You should not have to trust a big claim on a small website. You
@@ -51,7 +51,7 @@ export default function SocialProof() {
               data-umami-event="cta-click"
               data-umami-event-label="experience-proof"
             >
-              See The Proof
+              See How We Work
             </Button>
           </div>
         </div>


### PR DESCRIPTION
The site promised proof (nav item, three buttons, section heading, /work page framing) while /work has no case studies yet. Until #9 ships a real artifact, every label now describes what the click actually delivers.

## Closes #[issue-number]

## Summary
<!-- What was implemented (the issue captures why) -->

## Spec Checklist
- [ ] All **Rules** from the linked story are implemented
- [ ] **Examples** (scenarios) have been manually verified
- [ ] All **Questions** from the story are resolved or explicitly deferred
- [ ] Implementation stays within the story's defined **Out of Scope**

## How to test
1. 
2. 
