### PR TITLE
feat: migrate site onto amptech-design tokens + fonts (Phase 1+2)

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -12,42 +12,42 @@ export default function AboutPage() {
   return (
     <SectionWrapper>
       <div className="max-w-2xl">
-        <p className="text-sm font-medium uppercase tracking-wide text-brand-red mb-4">
+        <p className="text-sm font-medium uppercase tracking-wide text-amp-red mb-4">
           About
         </p>
-        <h1 className="display-type text-[3.5rem] leading-[0.92] text-brand-ink mb-6 sm:text-[4.7rem] md:text-[5.8rem]">
+        <h1 className="display-type text-[3.5rem] leading-[0.92] text-amp-ink mb-6 sm:text-[4.7rem] md:text-[5.8rem]">
           THE HELP
           <br />
           BEHIND THE
           <br />
           BUILD.
         </h1>
-        <p className="text-lg text-brand-gray leading-relaxed mb-6">
+        <p className="text-lg text-[var(--fg2)] leading-relaxed mb-6">
           AmpTech was founded for the moment when a promising build stops
           moving. The demo exists. The idea is still strong. But the project
           needs experienced engineering to become something real users can rely
           on.
         </p>
-        <p className="text-base text-brand-gray leading-relaxed mb-6">
+        <p className="text-base text-[var(--fg2)] leading-relaxed mb-6">
           We work with founders and business owners who have momentum, clarity,
           and a real product vision, but need help getting from rough version to
           launch-ready software.
         </p>
-        <p className="text-base text-brand-gray leading-relaxed mb-10">
+        <p className="text-base text-[var(--fg2)] leading-relaxed mb-10">
           We use modern AI-assisted development tools where they help, but the
           work is led by engineering judgment: architecture, tradeoffs,
           debugging, deployment, and clean ownership.
         </p>
         <div className="border border-gray-200 p-8 mb-10">
-          <p className="text-sm font-semibold uppercase tracking-widest text-brand-red mb-4">
+          <p className="text-sm font-semibold uppercase tracking-widest text-amp-red mb-4">
             What You Can Expect
           </p>
-          <p className="text-base text-brand-gray leading-relaxed mb-4">
+          <p className="text-base text-[var(--fg2)] leading-relaxed mb-4">
             20+ years of professional software development experience, direct
             communication, transparent scoping, and references from people who
             have worked with us directly.
           </p>
-          <p className="text-base text-brand-gray leading-relaxed">
+          <p className="text-base text-[var(--fg2)] leading-relaxed">
             The goal is simple: help you get from stuck build to real software
             without having to become a developer yourself.
           </p>

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -47,9 +47,9 @@ export default function ContactPage() {
     return (
       <SectionWrapper className="min-h-[60vh] flex items-center">
         <div className="max-w-lg mx-auto text-center">
-          <div className="w-12 h-12 rounded-full bg-brand-red-light flex items-center justify-center mx-auto mb-6">
+          <div className="w-12 h-12 rounded-full bg-amp-red/10 flex items-center justify-center mx-auto mb-6">
             <svg
-              className="w-6 h-6 text-brand-red"
+              className="w-6 h-6 text-amp-red"
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"
@@ -62,15 +62,15 @@ export default function ContactPage() {
               />
             </svg>
           </div>
-          <h2 className="text-3xl font-bold text-brand-black mb-4">
+          <h2 className="text-3xl font-bold text-amp-ink mb-4">
             Request received.
           </h2>
-          <p className="text-base text-brand-gray leading-relaxed">
+          <p className="text-base text-[var(--fg2)] leading-relaxed">
             Thanks for reaching out. Your request was submitted successfully.
             If you prefer, you can also email{" "}
             <a
               href="mailto:hello@amptech.dev"
-              className="text-brand-red underline underline-offset-4"
+              className="text-amp-red underline underline-offset-4"
             >
               hello@amptech.dev
             </a>
@@ -84,13 +84,13 @@ export default function ContactPage() {
   return (
     <SectionWrapper>
       <div className="max-w-xl">
-        <p className="text-sm font-medium uppercase tracking-wide text-brand-red mb-4">
+        <p className="text-sm font-medium uppercase tracking-wide text-amp-red mb-4">
           Get Started
         </p>
-        <h1 className="text-5xl font-bold tracking-tight text-brand-black mb-4">
+        <h1 className="text-5xl font-bold tracking-tight text-amp-ink mb-4">
           Book a Free Discovery Call
         </h1>
-        <p className="text-base text-brand-gray leading-relaxed mb-10">
+        <p className="text-base text-[var(--fg2)] leading-relaxed mb-10">
           Tell us about your idea. No technical knowledge required — just
           describe what you want to build and we&apos;ll take it from there.
         </p>
@@ -100,22 +100,22 @@ export default function ContactPage() {
           <div>
             <label
               htmlFor="name"
-              className="block text-sm font-medium text-brand-black mb-2"
+              className="block text-sm font-medium text-amp-ink mb-2"
             >
-              Name <span className="text-brand-red">*</span>
+              Name <span className="text-amp-red">*</span>
             </label>
             <input
               id="name"
               type="text"
               autoComplete="name"
-              className={`w-full border rounded px-4 py-3 text-base text-brand-black placeholder:text-gray-400 outline-none focus:ring-2 focus:ring-brand-red transition ${
-                errors.name ? "border-brand-red" : "border-gray-300"
+              className={`w-full border rounded px-4 py-3 text-base text-amp-ink placeholder:text-gray-400 outline-none focus:ring-2 focus:ring-amp-red transition ${
+                errors.name ? "border-amp-red" : "border-gray-300"
               }`}
               placeholder="Your full name"
               {...register("name", { required: "Name is required" })}
             />
             {errors.name && (
-              <p className="mt-1.5 text-sm text-brand-red">
+              <p className="mt-1.5 text-sm text-amp-red">
                 {errors.name.message}
               </p>
             )}
@@ -125,16 +125,16 @@ export default function ContactPage() {
           <div>
             <label
               htmlFor="email"
-              className="block text-sm font-medium text-brand-black mb-2"
+              className="block text-sm font-medium text-amp-ink mb-2"
             >
-              Email <span className="text-brand-red">*</span>
+              Email <span className="text-amp-red">*</span>
             </label>
             <input
               id="email"
               type="email"
               autoComplete="email"
-              className={`w-full border rounded px-4 py-3 text-base text-brand-black placeholder:text-gray-400 outline-none focus:ring-2 focus:ring-brand-red transition ${
-                errors.email ? "border-brand-red" : "border-gray-300"
+              className={`w-full border rounded px-4 py-3 text-base text-amp-ink placeholder:text-gray-400 outline-none focus:ring-2 focus:ring-amp-red transition ${
+                errors.email ? "border-amp-red" : "border-gray-300"
               }`}
               placeholder="you@example.com"
               {...register("email", {
@@ -146,7 +146,7 @@ export default function ContactPage() {
               })}
             />
             {errors.email && (
-              <p className="mt-1.5 text-sm text-brand-red">
+              <p className="mt-1.5 text-sm text-amp-red">
                 {errors.email.message}
               </p>
             )}
@@ -156,15 +156,15 @@ export default function ContactPage() {
           <div>
             <label
               htmlFor="idea"
-              className="block text-sm font-medium text-brand-black mb-2"
+              className="block text-sm font-medium text-amp-ink mb-2"
             >
-              Tell us about your idea <span className="text-brand-red">*</span>
+              Tell us about your idea <span className="text-amp-red">*</span>
             </label>
             <textarea
               id="idea"
               rows={5}
-              className={`w-full border rounded px-4 py-3 text-base text-brand-black placeholder:text-gray-400 outline-none focus:ring-2 focus:ring-brand-red transition resize-none ${
-                errors.idea ? "border-brand-red" : "border-gray-300"
+              className={`w-full border rounded px-4 py-3 text-base text-amp-ink placeholder:text-gray-400 outline-none focus:ring-2 focus:ring-amp-red transition resize-none ${
+                errors.idea ? "border-amp-red" : "border-gray-300"
               }`}
               placeholder="Describe the app you want to build — what it does, who it's for, and any context that helps us understand it."
               {...register("idea", {
@@ -176,7 +176,7 @@ export default function ContactPage() {
               })}
             />
             {errors.idea && (
-              <p className="mt-1.5 text-sm text-brand-red">
+              <p className="mt-1.5 text-sm text-amp-red">
                 {errors.idea.message}
               </p>
             )}
@@ -184,7 +184,7 @@ export default function ContactPage() {
 
           {/* Tried before */}
           <div>
-            <p className="block text-sm font-medium text-brand-black mb-3">
+            <p className="block text-sm font-medium text-amp-ink mb-3">
               Have you tried to build this before?
             </p>
             <div className="flex gap-4">
@@ -192,19 +192,19 @@ export default function ContactPage() {
                 <input
                   type="radio"
                   value="true"
-                  className="accent-brand-red"
+                  className="accent-amp-red"
                   {...register("triedBefore")}
                 />
-                <span className="text-sm text-brand-gray">Yes</span>
+                <span className="text-sm text-[var(--fg2)]">Yes</span>
               </label>
               <label className="flex items-center gap-2 cursor-pointer">
                 <input
                   type="radio"
                   value="false"
-                  className="accent-brand-red"
+                  className="accent-amp-red"
                   {...register("triedBefore")}
                 />
-                <span className="text-sm text-brand-gray">No</span>
+                <span className="text-sm text-[var(--fg2)]">No</span>
               </label>
             </div>
           </div>
@@ -213,13 +213,13 @@ export default function ContactPage() {
           <div>
             <label
               htmlFor="timeline"
-              className="block text-sm font-medium text-brand-black mb-2"
+              className="block text-sm font-medium text-amp-ink mb-2"
             >
               Rough timeline in mind?
             </label>
             <select
               id="timeline"
-              className="w-full border border-gray-300 rounded px-4 py-3 text-base text-brand-black outline-none focus:ring-2 focus:ring-brand-red transition bg-white"
+              className="w-full border border-gray-300 rounded px-4 py-3 text-base text-amp-ink outline-none focus:ring-2 focus:ring-amp-red transition bg-white"
               {...register("timeline")}
             >
               <option value="">Select one</option>
@@ -231,7 +231,7 @@ export default function ContactPage() {
           </div>
 
           {error && (
-            <p className="text-sm text-brand-red">
+            <p className="text-sm text-amp-red">
               Submissions are not configured on this deployment yet. Please
               email us directly at{" "}
               <a

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,91 +1,218 @@
+/* =========================================================================
+   AmpTech — globals.css  (Tailwind v4)
+   -------------------------------------------------------------------------
+   This file MIRRORS the canonical tokens in the amptech-design skill
+   (.claude/skills/amptech-design/colors_and_type.css). It is the ONLY
+   place brand colors/fonts/radii live in this repo.
+
+   RULES:
+   • Do NOT add new brand colors here or anywhere else. If the brand needs a
+     new token, add it to the skill's colors_and_type.css first, then mirror.
+   • No cream/warm palette. No candy gradients. Backgrounds are flat
+     white / near-black per the system.
+   • Fonts come from next/font in app/layout.tsx (see MIGRATION.md) and are
+     bound to the CSS vars below.
+   ========================================================================= */
+
 @import "tailwindcss";
 
 @theme {
-  --color-brand-red: #D41E10;
-  --color-brand-red-light: #FAE5E4;
-  --color-brand-gray: #4D4D4D;
-  --color-brand-black: #000000;
-  --color-brand-white: #FFFFFF;
-  --color-brand-gray-bg: #F5F5F5;
-  --color-brand-ink: #111111;
-  --color-brand-cream: #F1ECE4;
-  --color-brand-steel: #90877C;
-  --color-brand-night: #0B0B0C;
-  --color-brand-night-soft: #18181B;
+  /* ---------- BRAND CORE ------------------------------------------------ */
+  --color-amp-red:        #D41E10;   /* official brand red — accent only */
+  --color-amp-red-hot:    #EE2415;   /* hover */
+  --color-amp-red-deep:   #A21508;   /* pressed */
+  --color-amp-red-ember:  #680E06;   /* deep tint, dark surfaces */
+  --color-amp-steel:      #4D4D4D;   /* official brand gray (COOL, not warm) */
+  --color-amp-ink:        #141414;   /* near-black */
+  --color-amp-charcoal:   #1A1C20;
+  --color-amp-graphite:   #2A2D33;
 
-  --font-sans: var(--font-montserrat), Arial, sans-serif;
-  --font-display: var(--font-bebas), Impact, sans-serif;
+  /* ---------- NEUTRALS (cool graphite — NO warm cream/steel) ----------- */
+  --color-gray-0:   #FFFFFF;
+  --color-gray-50:  #F7F7F8;
+  --color-gray-100: #EEEEF0;
+  --color-gray-200: #DEDFE3;
+  --color-gray-300: #C4C6CC;
+  --color-gray-400: #9AA0A8;
+  --color-gray-500: #6B7280;
+  --color-gray-600: #4B5057;
+  --color-gray-700: #2F333A;
+  --color-gray-800: #1A1C20;
+  --color-gray-900: #141414;
+
+  /* ---------- STATUS ---------------------------------------------------- */
+  --color-success: #0F8D4E;
+  --color-warning: #C77700;
+  --color-danger:  #D41E10;   /* intentionally brand red */
+  --color-info:    #1D6FE0;
+
+  /* ---------- FONTS (bound to next/font vars in layout.tsx) ------------- */
+  --font-display: var(--font-space-grotesk), "Space Grotesk", system-ui, sans-serif;
+  --font-sans:    var(--font-inter), "Inter", system-ui, sans-serif;
+  --font-mono:    var(--font-jetbrains), "JetBrains Mono", ui-monospace, monospace;
+
+  /* ---------- RADII (angular: 2–14px; full-round only for avatars/pills) */
+  --radius-xs: 2px;
+  --radius-sm: 4px;
+  --radius-md: 6px;   /* buttons, inputs */
+  --radius-lg: 10px;  /* cards */
+  --radius-xl: 14px;  /* large cards / modals */
 }
 
-html {
-  scroll-behavior: smooth;
+/* =========================================================================
+   SEMANTIC TOKENS — light (default) + dark. Reference these in components
+   via var(); keep them in sync with the skill's colors_and_type.css.
+   ========================================================================= */
+:root {
+  --bg:        var(--color-gray-0);
+  --bg-subtle: var(--color-gray-50);
+  --bg-muted:  var(--color-gray-100);
+
+  --surface:        #FFFFFF;
+  --surface-raised: #FFFFFF;
+  --surface-sunken: var(--color-gray-50);
+
+  --fg1: var(--color-gray-900);  /* primary type */
+  --fg2: var(--color-gray-700);  /* secondary */
+  --fg3: var(--color-gray-500);  /* meta */
+  --fg-on-red: #FFFFFF;
+  --fg-on-ink: #FFFFFF;
+
+  --border:        var(--color-gray-200);
+  --border-strong: var(--color-gray-300);
+  --divider:       var(--color-gray-100);
+
+  --accent:         var(--color-amp-red);
+  --accent-hover:   var(--color-amp-red-hot);
+  --accent-pressed: var(--color-amp-red-deep);
+  --accent-subtle:  #FDECEA;
+
+  /* Shadows — precise, never cloudy */
+  --shadow-1: 0 1px 2px rgba(12,13,16,0.06), 0 0 0 1px rgba(12,13,16,0.04);
+  --shadow-2: 0 2px 6px rgba(12,13,16,0.08), 0 1px 2px rgba(12,13,16,0.04);
+  --shadow-3: 0 8px 24px rgba(12,13,16,0.10), 0 2px 6px rgba(12,13,16,0.06);
+  --shadow-red-glow: 0 0 0 3px rgba(212,30,16,0.18);   /* focus / "powered-on" */
+
+  /* Motion */
+  --ease-out:  cubic-bezier(0.2, 0.8, 0.2, 1);
+  --ease-snap: cubic-bezier(0.2, 0.9, 0.1, 1.05);
+  --dur-fast: 120ms;
+  --dur-base: 200ms;
+  --dur-slow: 320ms;
+
+  /* Approved controlled surfaces — the ONLY allowed gradients */
+  --grad-ink: linear-gradient(180deg, #242424 0%, #141414 100%);
 }
+
+[data-theme="dark"], .theme-dark {
+  --bg:        var(--color-amp-ink);
+  --bg-subtle: var(--color-amp-charcoal);
+  --bg-muted:  var(--color-amp-graphite);
+
+  --surface:        var(--color-amp-charcoal);
+  --surface-raised: #23262C;
+  --surface-sunken: var(--color-amp-ink);
+
+  --fg1: #F4F5F7;
+  --fg2: #C4C6CC;
+  --fg3: #9AA0A8;
+
+  --border:        #2A2D33;
+  --border-strong: #3A3E45;
+  --divider:       #23262C;
+
+  --accent:         var(--color-amp-red-hot);
+  --accent-hover:   #FF4450;
+  --accent-pressed: var(--color-amp-red);
+}
+
+/* =========================================================================
+   BASE — flat surfaces. No cream gradient body, no fixed gradient overlay.
+   ========================================================================= */
+html { scroll-behavior: smooth; }
 
 body {
-  background:
-    linear-gradient(180deg, #f7f2ea 0%, #f7f3ee 42%, #ffffff 100%);
-  color: #4D4D4D;
+  background: var(--bg);              /* flat — was a warm cream gradient */
+  color: var(--fg2);
+  font-family: var(--font-sans);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
 }
 
-a {
-  text-underline-offset: 0.2em;
-}
+a { color: var(--accent); text-underline-offset: 0.2em; }
+a:hover { color: var(--accent-hover); }
 
+::selection { background: var(--color-amp-red); color: #fff; }
+
+/* Headlines use the display font in SENTENCE CASE — never forced uppercase. */
 .display-type {
-  font-family: var(--font-display), Impact, sans-serif;
-  letter-spacing: 0.03em;
+  font-family: var(--font-display);
+  letter-spacing: -0.02em;          /* engineered, tight — not Bebas's +0.03em */
+  font-weight: 600;
+  text-wrap: balance;
 }
 
-.site-shell {
-  position: relative;
-}
+/* ---------- SIGNATURE MICRO-ELEMENTS (were missing entirely) ----------- */
 
-.site-shell::before {
+/* Eyebrow: 12px tracked uppercase RED label + 18px red bar. */
+.amp-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-sans);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+.amp-eyebrow::before {
   content: "";
-  position: fixed;
-  inset: 0;
-  z-index: -1;
-  pointer-events: none;
-  background:
-    linear-gradient(120deg, rgba(212, 30, 16, 0.055), transparent 28%),
-    linear-gradient(180deg, rgba(11, 11, 12, 0.04), transparent 34%);
-  opacity: 0.75;
+  width: 18px;
+  height: 2px;
+  background: var(--accent);
 }
 
-.hero-noise {
+/* Bolt-bar: 3px red left accent — pull-quotes / key callouts / active nav only. */
+.amp-bolt-bar {
   position: relative;
-  overflow: clip;
-  background:
-    linear-gradient(135deg, rgba(11, 11, 12, 0.99) 0%, rgba(19, 19, 21, 0.98) 62%, rgba(96, 16, 12, 0.96) 100%);
+  padding-left: 14px;
+}
+.amp-bolt-bar::before {
+  content: "";
+  position: absolute;
+  left: 0; top: 0.25em; bottom: 0.25em;
+  width: 3px;
+  background: var(--accent);
 }
 
-.hero-noise::before {
+/* Mono metrics: every number (uptime, latency, counts) renders engineered. */
+.amp-metric {
+  font-family: var(--font-mono);
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
+}
+
+/* Dark hero surface — flat ink (approved --grad-ink), no diagonal red wash. */
+.hero-ink {
+  background: var(--grad-ink);
+  color: var(--fg-on-ink);
+}
+
+/* Optional blueprint grid texture at low opacity — engineering signal. */
+.hero-ink::before {
   content: "";
   position: absolute;
   inset: 0;
   background:
-    linear-gradient(90deg, rgba(255, 255, 255, 0.06) 1px, transparent 1px),
-    linear-gradient(rgba(255, 255, 255, 0.06) 1px, transparent 1px);
+    linear-gradient(90deg, rgba(255,255,255,0.05) 1px, transparent 1px),
+    linear-gradient(rgba(255,255,255,0.05) 1px, transparent 1px);
   background-size: 84px 84px;
-  mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.95), transparent 92%);
-  opacity: 0.18;
+  mask-image: linear-gradient(180deg, rgba(0,0,0,0.9), transparent 92%);
+  opacity: 0.15;
+  pointer-events: none;
 }
 
-.hero-noise::after {
-  content: "";
-  position: absolute;
-  inset: auto 0 0 0;
-  height: 1px;
-  background: rgba(241, 236, 228, 0.28);
-}
-
-.section-rule {
-  border-top: 1px solid rgba(17, 17, 17, 0.12);
-}
-
-@media (max-width: 768px) {
-  body {
-    background:
-      linear-gradient(180deg, #f7f2ea 0%, #ffffff 72%);
-  }
-}
+.section-rule { border-top: 1px solid var(--border); }

--- a/app/globals.css
+++ b/app/globals.css
@@ -128,22 +128,26 @@
 
 /* =========================================================================
    BASE — flat surfaces. No cream gradient body, no fixed gradient overlay.
+   Kept in @layer base so Tailwind utilities (e.g. text-white on link-buttons)
+   still win — unlayered rules would otherwise beat every utility.
    ========================================================================= */
-html { scroll-behavior: smooth; }
+@layer base {
+  html { scroll-behavior: smooth; }
 
-body {
-  background: var(--bg);              /* flat — was a warm cream gradient */
-  color: var(--fg2);
-  font-family: var(--font-sans);
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  text-rendering: optimizeLegibility;
+  body {
+    background: var(--bg);              /* flat — was a warm cream gradient */
+    color: var(--fg2);
+    font-family: var(--font-sans);
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-rendering: optimizeLegibility;
+  }
+
+  a { color: var(--accent); text-underline-offset: 0.2em; }
+  a:hover { color: var(--accent-hover); }
+
+  ::selection { background: var(--color-amp-red); color: #fff; }
 }
-
-a { color: var(--accent); text-underline-offset: 0.2em; }
-a:hover { color: var(--accent-hover); }
-
-::selection { background: var(--color-amp-red); color: #fff; }
 
 /* Headlines use the display font in SENTENCE CASE — never forced uppercase. */
 .display-type {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,19 +1,25 @@
 import type { Metadata } from "next";
-import { Bebas_Neue, Montserrat } from "next/font/google";
+import { Space_Grotesk, Inter, JetBrains_Mono } from "next/font/google";
 import Script from "next/script";
 import "./globals.css";
 import Nav from "@/components/layout/Nav";
 import Footer from "@/components/layout/Footer";
 
-const bebasNeue = Bebas_Neue({
+const spaceGrotesk = Space_Grotesk({
   subsets: ["latin"],
-  weight: "400",
-  variable: "--font-bebas",
+  weight: ["400", "500", "600", "700"],
+  variable: "--font-space-grotesk",
 });
 
-const montserrat = Montserrat({
+const inter = Inter({
   subsets: ["latin"],
-  variable: "--font-montserrat",
+  variable: "--font-inter",
+});
+
+const jetbrainsMono = JetBrains_Mono({
+  subsets: ["latin"],
+  weight: ["400", "500", "700"],
+  variable: "--font-jetbrains",
 });
 
 export const metadata: Metadata = {
@@ -28,8 +34,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={`${montserrat.variable} ${bebasNeue.variable}`}>
-      <body className="site-shell antialiased font-sans">
+    <html
+      lang="en"
+      className={`${spaceGrotesk.variable} ${inter.variable} ${jetbrainsMono.variable}`}
+    >
+      <body className="antialiased font-sans">
         <Nav />
         {children}
         <Footer />

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -30,17 +30,17 @@ export default function ServicesPage() {
   return (
     <SectionWrapper>
       <div className="max-w-5xl">
-        <p className="mb-4 text-sm font-semibold uppercase tracking-[0.24em] text-brand-red">
+        <p className="mb-4 text-sm font-semibold uppercase tracking-[0.24em] text-amp-red">
           Services
         </p>
-        <h1 className="display-type max-w-4xl text-[3.5rem] leading-[0.92] text-brand-ink sm:text-[4.7rem] md:text-[5.8rem]">
+        <h1 className="display-type max-w-4xl text-[3.5rem] leading-[0.92] text-amp-ink sm:text-[4.7rem] md:text-[5.8rem]">
           FROM STUCK
           <br />
           TO SHIPPED,
           <br />
           DONE RIGHT.
         </h1>
-        <p className="mt-6 max-w-3xl text-lg leading-relaxed text-brand-gray">
+        <p className="mt-6 max-w-3xl text-lg leading-relaxed text-[var(--fg2)]">
           AmpTech helps founders and business owners turn rough prototypes,
           stalled AI builds, and app ideas into software that holds up under
           real use.
@@ -49,10 +49,10 @@ export default function ServicesPage() {
         <div className="mt-16 grid gap-5 border-t border-black/10 pt-8 md:grid-cols-2">
           {serviceAreas.map((service) => (
             <div key={service.title} className="section-rule pt-5">
-              <p className="mb-3 text-sm font-semibold uppercase tracking-[0.2em] text-brand-red">
+              <p className="mb-3 text-sm font-semibold uppercase tracking-[0.2em] text-amp-red">
                 {service.title}
               </p>
-              <p className="text-base leading-relaxed text-brand-gray">
+              <p className="text-base leading-relaxed text-[var(--fg2)]">
                 {service.body}
               </p>
             </div>
@@ -60,10 +60,10 @@ export default function ServicesPage() {
         </div>
 
         <div className="mt-16 border-t border-black/10 pt-8">
-          <p className="mb-4 text-sm font-semibold uppercase tracking-[0.24em] text-brand-red">
+          <p className="mb-4 text-sm font-semibold uppercase tracking-[0.24em] text-amp-red">
             Engagement Model
           </p>
-          <div className="max-w-3xl space-y-4 text-base leading-relaxed text-brand-gray">
+          <div className="max-w-3xl space-y-4 text-base leading-relaxed text-[var(--fg2)]">
             <p>
               Every engagement starts with a discovery call. If the build is a
               fit, the next step is scoped planning so you know what can be

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -22,10 +22,10 @@ export default function WorkPage() {
   return (
     <SectionWrapper>
       <div className="max-w-5xl">
-        <p className="mb-4 text-sm font-semibold uppercase tracking-[0.24em] text-brand-red">
+        <p className="mb-4 text-sm font-semibold uppercase tracking-[0.24em] text-amp-red">
           How We Work
         </p>
-        <h1 className="display-type max-w-4xl text-[3.5rem] leading-[0.92] text-brand-ink sm:text-[4.7rem] md:text-[5.8rem]">
+        <h1 className="display-type max-w-4xl text-[3.5rem] leading-[0.92] text-amp-ink sm:text-[4.7rem] md:text-[5.8rem]">
           HOW TO
           <br />
           TELL IF
@@ -34,7 +34,7 @@ export default function WorkPage() {
           <br />
           CAN WORK.
         </h1>
-        <p className="mt-6 max-w-3xl text-lg leading-relaxed text-brand-gray">
+        <p className="mt-6 max-w-3xl text-lg leading-relaxed text-[var(--fg2)]">
           If you are deciding whether AmpTech is the right fit, start here. The
           right partner should make the project clearer before they ask you to
           commit to the build.
@@ -43,10 +43,10 @@ export default function WorkPage() {
         <div className="mt-16 grid gap-5 border-t border-black/10 pt-8 md:grid-cols-2">
           {proofBlocks.map((block) => (
             <div key={block.title} className="section-rule pt-5">
-              <p className="mb-3 text-sm font-semibold uppercase tracking-[0.2em] text-brand-red">
+              <p className="mb-3 text-sm font-semibold uppercase tracking-[0.2em] text-amp-red">
                 {block.title}
               </p>
-              <p className="text-base leading-relaxed text-brand-gray">
+              <p className="text-base leading-relaxed text-[var(--fg2)]">
                 {block.body}
               </p>
             </div>
@@ -54,10 +54,10 @@ export default function WorkPage() {
         </div>
 
         <div className="mt-16 border-t border-black/10 pt-8">
-          <p className="mb-4 text-sm font-semibold uppercase tracking-[0.24em] text-brand-red">
+          <p className="mb-4 text-sm font-semibold uppercase tracking-[0.24em] text-amp-red">
             What That Means For You
           </p>
-          <div className="max-w-3xl space-y-4 text-base leading-relaxed text-brand-gray">
+          <div className="max-w-3xl space-y-4 text-base leading-relaxed text-[var(--fg2)]">
             <p>
               You should know what can be kept, what needs rebuilding, what the
               tradeoffs are, and who is making the technical decisions before

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -3,7 +3,7 @@ import Image from "next/image";
 
 export default function Footer() {
   return (
-    <footer className="bg-brand-black text-white py-12 px-4 sm:px-6 lg:px-8">
+    <footer className="bg-amp-ink text-white py-12 px-4 sm:px-6 lg:px-8">
       <div className="max-w-5xl mx-auto">
         <div className="flex flex-col md:flex-row justify-between items-start gap-8">
           {/* Logo + tagline */}

--- a/components/layout/Nav.tsx
+++ b/components/layout/Nav.tsx
@@ -9,7 +9,7 @@ export default function Nav() {
   const [menuOpen, setMenuOpen] = useState(false);
 
   return (
-    <header className="sticky top-0 z-50 border-b border-white/10 bg-brand-night/80 text-white backdrop-blur-xl">
+    <header className="sticky top-0 z-50 border-b border-white/10 bg-amp-ink/80 text-white backdrop-blur-xl">
       <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
         <div className="flex h-16 items-center justify-between">
           <Link href="/" aria-label="AmpTech home">

--- a/components/sections/ClosingCTA.tsx
+++ b/components/sections/ClosingCTA.tsx
@@ -5,7 +5,7 @@ import Button from "@/components/ui/Button";
 
 export default function ClosingCTA() {
   return (
-    <section className="bg-brand-night px-4 py-28 sm:px-6 lg:px-8">
+    <section className="bg-amp-ink px-4 py-28 sm:px-6 lg:px-8">
       <div className="mx-auto max-w-6xl">
         <motion.div
           initial={false}
@@ -14,7 +14,7 @@ export default function ClosingCTA() {
           transition={{ duration: 0.6, ease: "easeOut" }}
           className="max-w-4xl"
         >
-          <p className="mb-6 text-sm font-semibold uppercase tracking-[0.24em] text-brand-red-light/80">
+          <p className="mb-6 text-sm font-semibold uppercase tracking-[0.24em] text-amp-red/80">
             Ready To Build
           </p>
           <h2 className="display-type mb-6 text-[3.7rem] leading-[0.92] text-white sm:text-[5rem] md:text-[6.4rem]">
@@ -44,7 +44,7 @@ export default function ClosingCTA() {
               Or email{" "}
               <a
                 href="mailto:hello@amptech.dev"
-                className="text-brand-red hover:underline underline-offset-4"
+                className="text-amp-red hover:underline underline-offset-4"
               >
                 hello@amptech.dev
               </a>

--- a/components/sections/Guide.tsx
+++ b/components/sections/Guide.tsx
@@ -24,20 +24,20 @@ const features = [
 
 export default function Guide() {
   return (
-    <SectionWrapper className="bg-brand-gray-bg">
+    <SectionWrapper className="bg-[var(--bg-subtle)]">
       <motion.div
         initial={false}
         whileInView={{ opacity: 1, y: 0 }}
         viewport={{ once: true }}
         transition={{ duration: 0.6, ease: "easeOut" }}
       >
-        <p className="mb-4 text-sm font-semibold uppercase tracking-[0.24em] text-brand-red">
+        <p className="mb-4 text-sm font-semibold uppercase tracking-[0.24em] text-amp-red">
           Why AmpTech
         </p>
 
         <div className="grid gap-12 border-t border-black/10 pt-10 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
           <div>
-            <p className="display-type max-w-3xl text-[3.3rem] leading-[0.92] text-brand-ink sm:text-[4.4rem] md:text-[5.5rem]">
+            <p className="display-type max-w-3xl text-[3.3rem] leading-[0.92] text-amp-ink sm:text-[4.4rem] md:text-[5.5rem]">
               YOU NEED
               <br />
               SOMEONE WHO
@@ -50,7 +50,7 @@ export default function Guide() {
             </p>
           </div>
           <div>
-            <p className="text-lg leading-relaxed text-brand-gray">
+            <p className="text-lg leading-relaxed text-[var(--fg2)]">
               AmpTech brings senior engineering judgment to the messy middle of
               a build: the point where a prototype exists, but the product is
               not stable enough to sell, demo, or depend on.
@@ -68,10 +68,10 @@ export default function Guide() {
               transition={{ duration: 0.5, delay: i * 0.08, ease: "easeOut" }}
               className="section-rule pt-5"
             >
-              <p className="mb-3 text-sm font-semibold uppercase tracking-[0.2em] text-brand-red">
+              <p className="mb-3 text-sm font-semibold uppercase tracking-[0.2em] text-amp-red">
                 {feature.title}
               </p>
-              <p className="text-base leading-relaxed text-brand-gray">
+              <p className="text-base leading-relaxed text-[var(--fg2)]">
                 {feature.description}
               </p>
             </motion.div>

--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -11,7 +11,7 @@ const capabilityMarks = [
 
 export default function Hero() {
   return (
-    <section className="hero-noise min-h-[calc(100svh-4rem)] text-white">
+    <section className="hero-ink relative overflow-clip min-h-[calc(100svh-4rem)] text-white">
       <div className="mx-auto grid min-h-[calc(100svh-4rem)] max-w-7xl px-4 sm:px-6 lg:grid-cols-[minmax(0,1.2fr)_minmax(19rem,0.8fr)] lg:px-8">
         <motion.div
           initial={false}
@@ -23,7 +23,7 @@ export default function Hero() {
             initial={false}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.55, delay: 0.05, ease: "easeOut" }}
-            className="mb-6 text-sm font-semibold uppercase tracking-[0.28em] text-brand-cream/70"
+            className="mb-6 text-sm font-semibold uppercase tracking-[0.28em] text-white/70"
           >
             AmpTech
           </motion.p>
@@ -32,14 +32,14 @@ export default function Hero() {
             initial={false}
             animate={{ scaleX: 1 }}
             transition={{ duration: 0.55, ease: "easeOut", delay: 0.1 }}
-            className="mb-8 h-px w-24 origin-left bg-brand-cream/40"
+            className="mb-8 h-px w-24 origin-left bg-white/40"
           />
 
           <motion.h1
             initial={false}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.75, delay: 0.12, ease: "easeOut" }}
-            className="display-type max-w-4xl text-[3.35rem] leading-[0.9] text-brand-cream sm:text-[6rem] md:text-[7.8rem] lg:text-[8.8rem]"
+            className="display-type max-w-4xl text-[3.35rem] leading-[0.9] text-white sm:text-[6rem] md:text-[7.8rem] lg:text-[8.8rem]"
           >
             YOU HAVE
             <br />
@@ -47,14 +47,14 @@ export default function Hero() {
             <br />
             NOW BUILD
             <br />
-            <span className="text-brand-red-light">THE PRODUCT.</span>
+            <span className="text-amp-red">THE PRODUCT.</span>
           </motion.h1>
 
           <motion.p
             initial={false}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.6, delay: 0.22, ease: "easeOut" }}
-            className="mt-6 max-w-2xl text-base leading-relaxed text-brand-cream/82 sm:text-lg"
+            className="mt-6 max-w-2xl text-base leading-relaxed text-white/82 sm:text-lg"
           >
             AmpTech helps founders and business owners turn promising AI builds,
             rough prototypes, and half-finished app ideas into software people
@@ -79,7 +79,7 @@ export default function Hero() {
             <Button
               href="/work"
               variant="secondary"
-              className="border-white/50 text-white hover:bg-white hover:text-brand-night"
+              className="border-white/50 text-white hover:bg-white hover:text-amp-ink"
             >
               See How We Work
             </Button>
@@ -89,11 +89,11 @@ export default function Hero() {
             initial={false}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.55, delay: 0.38, ease: "easeOut" }}
-            className="mt-8 grid gap-3 text-xs uppercase tracking-[0.22em] text-brand-cream/60 sm:mt-10 sm:flex sm:flex-wrap sm:gap-5 sm:text-sm"
+            className="mt-8 grid gap-3 text-xs uppercase tracking-[0.22em] text-white/60 sm:mt-10 sm:flex sm:flex-wrap sm:gap-5 sm:text-sm"
           >
             {capabilityMarks.map((signal) => (
               <div key={signal} className="flex items-center gap-2.5">
-                <span className="h-1.5 w-1.5 rounded-full bg-brand-red-light" />
+                <span className="h-1.5 w-1.5 rounded-full bg-amp-red" />
                 <span className="font-semibold">{signal}</span>
               </div>
             ))}
@@ -106,7 +106,7 @@ export default function Hero() {
             className="mt-16 flex items-end lg:hidden"
           >
             <div className="w-full border-t border-white/18 pt-6">
-              <p className="text-xs uppercase tracking-[0.24em] text-brand-cream/52">
+              <p className="text-xs uppercase tracking-[0.24em] text-white/52">
                 You do not need another prompt. You need a build that holds up.
               </p>
             </div>
@@ -122,16 +122,16 @@ export default function Hero() {
           <div className="relative w-full max-w-md">
             <div className="absolute inset-x-0 top-10 h-px bg-white/18" />
             <div className="ml-auto w-[88%]">
-              <div className="display-type text-right text-[8.4rem] leading-[0.82] text-brand-cream/14">
+              <div className="display-type text-right text-[8.4rem] leading-[0.82] text-white/14">
                 DEMO
                 <br />
                 PRODUCT
               </div>
               <div className="-mt-4 border-l border-white/18 pl-6">
-                <p className="text-sm uppercase tracking-[0.24em] text-brand-cream/48">
+                <p className="text-sm uppercase tracking-[0.24em] text-white/48">
                   The hard part starts after the demo works.
                 </p>
-                <p className="mt-3 max-w-xs text-lg leading-relaxed text-brand-cream/78">
+                <p className="mt-3 max-w-xs text-lg leading-relaxed text-white/78">
                   We turn the rough version into the version you can show,
                   launch, own, and keep improving.
                 </p>

--- a/components/sections/Plan.tsx
+++ b/components/sections/Plan.tsx
@@ -23,17 +23,17 @@ const steps = [
 
 export default function Plan() {
   return (
-    <SectionWrapper className="bg-brand-night text-white">
+    <SectionWrapper className="bg-amp-ink text-white">
       <motion.div
         initial={false}
         whileInView={{ opacity: 1, y: 0 }}
         viewport={{ once: true }}
         transition={{ duration: 0.6, ease: "easeOut" }}
       >
-        <p className="mb-4 text-sm font-semibold uppercase tracking-[0.24em] text-brand-red-light/80">
+        <p className="mb-4 text-sm font-semibold uppercase tracking-[0.24em] text-amp-red/80">
           The Plan
         </p>
-        <h2 className="display-type mb-14 max-w-4xl text-[3.3rem] leading-[0.92] text-brand-cream sm:text-[4.4rem] md:text-[5.4rem]">
+        <h2 className="display-type mb-14 max-w-4xl text-[3.3rem] leading-[0.92] text-white sm:text-[4.4rem] md:text-[5.4rem]">
           A SIMPLE PATH
           <br />
           FROM STUCK

--- a/components/sections/Problem.tsx
+++ b/components/sections/Problem.tsx
@@ -12,13 +12,13 @@ export default function Problem() {
           viewport={{ once: true }}
           transition={{ duration: 0.6, ease: "easeOut" }}
         >
-          <p className="mb-8 text-sm font-semibold uppercase tracking-[0.24em] text-brand-red">
+          <p className="mb-8 text-sm font-semibold uppercase tracking-[0.24em] text-amp-red">
             The Problem
           </p>
 
           <div className="section-rule grid gap-12 pt-10 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)]">
             <div className="max-w-3xl">
-              <p className="display-type text-[3.7rem] leading-[0.92] text-brand-ink sm:text-[5rem] md:text-[6.4rem]">
+              <p className="display-type text-[3.7rem] leading-[0.92] text-amp-ink sm:text-[5rem] md:text-[6.4rem]">
                 THE DEMO
                 <br />
                 WORKED.
@@ -30,16 +30,16 @@ export default function Problem() {
             </div>
 
             <div className="space-y-6 pt-2">
-              <p className="text-lg leading-relaxed text-brand-gray">
+              <p className="text-lg leading-relaxed text-[var(--fg2)]">
                 You got a screen on the page. Maybe a workflow clicked through.
                 Maybe it even felt like the product was almost there.
               </p>
-              <p className="text-lg leading-relaxed text-brand-gray">
+              <p className="text-lg leading-relaxed text-[var(--fg2)]">
                 Then the hidden work started. Authentication broke. Data did
                 not save cleanly. Edge cases piled up. The AI kept changing the
                 same files and the project stopped getting closer to launch.
               </p>
-              <p className="text-sm uppercase tracking-[0.24em] text-brand-steel">
+              <p className="text-sm uppercase tracking-[0.24em] text-amp-steel">
                 The gap between promising and launch-ready is where most builds
                 stall.
               </p>

--- a/components/sections/SocialProof.tsx
+++ b/components/sections/SocialProof.tsx
@@ -21,13 +21,13 @@ export default function SocialProof() {
       >
         <div className="flex flex-col gap-10 md:flex-row md:items-center md:justify-between">
           <div className="max-w-xl">
-            <p className="mb-4 text-sm font-semibold uppercase tracking-[0.24em] text-brand-red">
+            <p className="mb-4 text-sm font-semibold uppercase tracking-[0.24em] text-amp-red">
               Confidence
             </p>
-            <h2 className="display-type mb-4 text-[3rem] leading-[0.92] text-brand-ink sm:text-[3.9rem] md:text-[4.6rem]">
+            <h2 className="display-type mb-4 text-[3rem] leading-[0.92] text-amp-ink sm:text-[3.9rem] md:text-[4.6rem]">
               Look before you book.
             </h2>
-            <p className="text-lg leading-relaxed text-brand-gray">
+            <p className="text-lg leading-relaxed text-[var(--fg2)]">
               You should not have to trust a big claim on a small website. You
               should be able to see how we think, how we scope, and what kind
               of work we can carry across the finish line.
@@ -35,8 +35,8 @@ export default function SocialProof() {
             <div className="mt-10 space-y-5 border-t border-black/10 pt-6">
               {proofPoints.map((point) => (
                 <div key={point} className="flex items-start gap-3">
-                  <span className="mt-2 h-2 w-2 flex-shrink-0 rounded-full bg-brand-red" />
-                  <p className="text-base leading-relaxed text-brand-gray">
+                  <span className="mt-2 h-2 w-2 flex-shrink-0 rounded-full bg-amp-red" />
+                  <p className="text-base leading-relaxed text-[var(--fg2)]">
                     {point}
                   </p>
                 </div>
@@ -47,7 +47,7 @@ export default function SocialProof() {
             <Button
               href="/work"
               variant="secondary"
-              className="border-brand-ink text-brand-ink hover:bg-brand-ink"
+              className="border-amp-ink text-amp-ink hover:bg-amp-ink"
               data-umami-event="cta-click"
               data-umami-event-label="experience-proof"
             >

--- a/components/sections/Success.tsx
+++ b/components/sections/Success.tsx
@@ -30,7 +30,7 @@ function CheckIcon() {
       viewBox="0 0 16 16"
       fill="none"
       aria-hidden="true"
-      className="flex-shrink-0 text-brand-red"
+      className="flex-shrink-0 text-amp-red"
     >
       <path
         d="M2.5 8.5l3.5 3.5 7.5-8"
@@ -52,10 +52,10 @@ export default function Success() {
         viewport={{ once: true }}
         transition={{ duration: 0.6, ease: "easeOut" }}
       >
-        <p className="mb-4 text-sm font-semibold uppercase tracking-[0.24em] text-brand-red">
+        <p className="mb-4 text-sm font-semibold uppercase tracking-[0.24em] text-amp-red">
           Success
         </p>
-        <h2 className="display-type mb-14 max-w-4xl text-[3.3rem] leading-[0.92] text-brand-ink sm:text-[4.3rem] md:text-[5.2rem]">
+        <h2 className="display-type mb-14 max-w-4xl text-[3.3rem] leading-[0.92] text-amp-ink sm:text-[4.3rem] md:text-[5.2rem]">
           WHAT CHANGES
           <br />
           WHEN THE
@@ -75,14 +75,14 @@ export default function Success() {
               transition={{ duration: 0.5, delay: i * 0.1, ease: "easeOut" }}
               className="flex items-start gap-4"
             >
-              <div className="mt-0.5 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-brand-red-light">
+              <div className="mt-0.5 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-amp-red/10">
                 <CheckIcon />
               </div>
               <div>
-                <h3 className="mb-1 text-lg font-bold leading-snug text-brand-black">
+                <h3 className="mb-1 text-lg font-bold leading-snug text-amp-ink">
                   {item.headline}
                 </h3>
-                <p className="text-base leading-relaxed text-brand-gray">
+                <p className="text-base leading-relaxed text-[var(--fg2)]">
                   {item.body}
                 </p>
               </div>

--- a/components/ui/Badge.tsx
+++ b/components/ui/Badge.tsx
@@ -6,7 +6,7 @@ interface BadgeProps {
 export default function Badge({ children, className = "" }: BadgeProps) {
   return (
     <span
-      className={`inline-block text-sm font-medium uppercase tracking-wide bg-brand-red-light text-brand-red px-4 py-2 rounded-full ${className}`}
+      className={`inline-block text-sm font-medium uppercase tracking-wide bg-amp-red/10 text-amp-red px-4 py-2 rounded-full ${className}`}
     >
       {children}
     </span>

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -5,15 +5,15 @@ type Variant = "primary" | "secondary" | "ghost";
 
 const variantClasses: Record<Variant, string> = {
   primary:
-    "bg-brand-red text-white hover:bg-[#b8190d] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-brand-red",
+    "bg-amp-red text-white hover:bg-amp-red-hot focus-visible:outline-none focus-visible:shadow-[var(--shadow-red-glow)]",
   secondary:
     "border border-current text-current hover:bg-current hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-current",
   ghost:
-    "text-brand-red hover:underline underline-offset-4 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-brand-red",
+    "text-amp-red hover:underline underline-offset-4 focus-visible:outline-none focus-visible:shadow-[var(--shadow-red-glow)]",
 };
 
 const base =
-  "inline-flex cursor-pointer items-center justify-center rounded-full px-6 py-3 text-sm font-semibold uppercase tracking-[0.16em] transition-all duration-200";
+  "inline-flex cursor-pointer items-center justify-center rounded-md px-6 py-3 text-sm font-semibold uppercase tracking-[0.16em] transition-all duration-200";
 
 type LinkButtonProps = {
   variant?: Variant;


### PR DESCRIPTION
## Closes #26
## Closes #27

## Summary
Migrates the site onto the amptech-design system (epic #24, Phases 1 + 2 combined per grooming, so `main` is never visually broken). The old warm `brand-*` palette and Montserrat/Bebas fonts are gone; everything now references the canonical `amp-*` / semantic tokens.

**Phase 1 — tokens & fonts** (`a06555a`)
- `app/globals.css` ← canonical amptech tokens (amp-* colors, gray-0..900, semantic `--accent`/`--fg*`/`--surface`, signature classes, flat surfaces)
- `app/layout.tsx` ← Space Grotesk / Inter / JetBrains Mono via `next/font`; dropped Bebas, Montserrat, and `site-shell`

**Phase 2 — component migration** (`a3cb2be`)
- All 13 components/pages moved off `brand-*` → `amp-*`/semantic tokens
- Button → `rounded-md`, `hover:bg-amp-red-hot`, red-glow focus; Badge → `bg-amp-red/10`; Nav/Footer surfaces → `amp-ink`; Hero `hero-noise` → `hero-ink`

**Fix — Tailwind v4 layering** (`c7daadd`)
- The handoff globals.css declared base element rules unlayered. In Tailwind v4 unlayered rules beat every `@layer` (incl. utilities) regardless of specificity, so `a { color: var(--accent) }` overrode `text-white` on link-buttons — the primary CTA rendered **red-on-red (invisible)**. Wrapped base rules in `@layer base` so utilities win.

## Spec Checklist
- [x] `globals.css` replaced with amptech tokens; `layout.tsx` loads the three fonts; Bebas/Montserrat/`site-shell` removed
- [x] `rg "brand-(cream|steel|night|gray-bg)"` → 0 (in fact **all** `brand-*` → 0)
- [x] `npx tsc --noEmit` and `npm run build` pass
- [x] **Visually verified in-browser** (dev server, screenshots + computed-style inspection): hero `hero-ink` dark bg, Space Grotesk headlines, white-on-red primary CTA, light sections render dark-on-white, no console errors

## Verification
- `tsc` clean · `npm run build` clean · `rg "brand-"` across `app/` + `components/` → 0
- Screenshots: hero (dark), Plan (dark), SocialProof (light) — all correct after the layer fix

## Out of scope → remaining for #28 (visual pass)
- Signature-element application (eyebrow `.amp-eyebrow`, `.amp-bolt-bar`, `.amp-metric` on numbers)
- Nav active-state bolt-bar
- Button sentence-casing (buttons still `uppercase`; brand wants sentence case — coordinate with #19 copy)
- Hero headline sentence-casing (belongs to #19)
- Full mobile + desktop QA against the skill's `preview/` cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)
