### PR TITLE
feat: design-system signature elements + Lucide (Phase 3)

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -12,7 +12,7 @@ export default function AboutPage() {
   return (
     <SectionWrapper>
       <div className="max-w-2xl">
-        <p className="text-sm font-medium uppercase tracking-wide text-amp-red mb-4">
+        <p className="amp-eyebrow mb-4">
           About
         </p>
         <h1 className="display-type text-[3.5rem] leading-[0.92] text-amp-ink mb-6 sm:text-[4.7rem] md:text-[5.8rem]">
@@ -43,9 +43,9 @@ export default function AboutPage() {
             What You Can Expect
           </p>
           <p className="text-base text-[var(--fg2)] leading-relaxed mb-4">
-            20+ years of professional software development experience, direct
-            communication, transparent scoping, and references from people who
-            have worked with us directly.
+            <span className="amp-metric">20+ years</span> of professional
+            software development experience, direct communication, transparent
+            scoping, and references from people who have worked with us directly.
           </p>
           <p className="text-base text-[var(--fg2)] leading-relaxed">
             The goal is simple: help you get from stuck build to real software

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useForm } from "react-hook-form";
+import { Check } from "lucide-react";
 import SectionWrapper from "@/components/ui/SectionWrapper";
 import Button from "@/components/ui/Button";
 
@@ -47,20 +48,13 @@ export default function ContactPage() {
     return (
       <SectionWrapper className="min-h-[60vh] flex items-center">
         <div className="max-w-lg mx-auto text-center">
-          <div className="w-12 h-12 rounded-full bg-amp-red/10 flex items-center justify-center mx-auto mb-6">
-            <svg
-              className="w-6 h-6 text-amp-red"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
+          <div className="w-12 h-12 rounded-lg bg-amp-red/10 flex items-center justify-center mx-auto mb-6">
+            <Check
+              size={24}
               strokeWidth={2}
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M5 13l4 4L19 7"
-              />
-            </svg>
+              className="text-amp-red"
+              aria-hidden
+            />
           </div>
           <h2 className="text-3xl font-bold text-amp-ink mb-4">
             Request received.

--- a/app/globals.css
+++ b/app/globals.css
@@ -152,7 +152,7 @@
 /* Headlines use the display font in SENTENCE CASE — never forced uppercase. */
 .display-type {
   font-family: var(--font-display);
-  letter-spacing: -0.02em;          /* engineered, tight — not Bebas's +0.03em */
+  letter-spacing: -0.02em;          /* engineered, tight — not a loose display tracking */
   font-weight: 600;
   text-wrap: balance;
 }

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -30,7 +30,7 @@ export default function ServicesPage() {
   return (
     <SectionWrapper>
       <div className="max-w-5xl">
-        <p className="mb-4 text-sm font-semibold uppercase tracking-[0.24em] text-amp-red">
+        <p className="amp-eyebrow mb-4">
           Services
         </p>
         <h1 className="display-type max-w-4xl text-[3.5rem] leading-[0.92] text-amp-ink sm:text-[4.7rem] md:text-[5.8rem]">
@@ -49,7 +49,7 @@ export default function ServicesPage() {
         <div className="mt-16 grid gap-5 border-t border-black/10 pt-8 md:grid-cols-2">
           {serviceAreas.map((service) => (
             <div key={service.title} className="section-rule pt-5">
-              <p className="mb-3 text-sm font-semibold uppercase tracking-[0.2em] text-amp-red">
+              <p className="amp-eyebrow mb-3">
                 {service.title}
               </p>
               <p className="text-base leading-relaxed text-[var(--fg2)]">
@@ -60,7 +60,7 @@ export default function ServicesPage() {
         </div>
 
         <div className="mt-16 border-t border-black/10 pt-8">
-          <p className="mb-4 text-sm font-semibold uppercase tracking-[0.24em] text-amp-red">
+          <p className="amp-eyebrow mb-4">
             Engagement Model
           </p>
           <div className="max-w-3xl space-y-4 text-base leading-relaxed text-[var(--fg2)]">

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -10,7 +10,12 @@ export const metadata = {
 const proofBlocks = [
   {
     title: "Experience",
-    body: "20+ years of professional software development across real products, real users, and real delivery pressure.",
+    body: (
+      <>
+        <span className="amp-metric">20+ years</span> of professional software
+        development across real products, real users, and real delivery pressure.
+      </>
+    ),
   },
   {
     title: "References",
@@ -22,7 +27,7 @@ export default function WorkPage() {
   return (
     <SectionWrapper>
       <div className="max-w-5xl">
-        <p className="mb-4 text-sm font-semibold uppercase tracking-[0.24em] text-amp-red">
+        <p className="amp-eyebrow mb-4">
           How We Work
         </p>
         <h1 className="display-type max-w-4xl text-[3.5rem] leading-[0.92] text-amp-ink sm:text-[4.7rem] md:text-[5.8rem]">
@@ -43,7 +48,7 @@ export default function WorkPage() {
         <div className="mt-16 grid gap-5 border-t border-black/10 pt-8 md:grid-cols-2">
           {proofBlocks.map((block) => (
             <div key={block.title} className="section-rule pt-5">
-              <p className="mb-3 text-sm font-semibold uppercase tracking-[0.2em] text-amp-red">
+              <p className="amp-eyebrow mb-3">
                 {block.title}
               </p>
               <p className="text-base leading-relaxed text-[var(--fg2)]">
@@ -54,7 +59,7 @@ export default function WorkPage() {
         </div>
 
         <div className="mt-16 border-t border-black/10 pt-8">
-          <p className="mb-4 text-sm font-semibold uppercase tracking-[0.24em] text-amp-red">
+          <p className="amp-eyebrow mb-4">
             What That Means For You
           </p>
           <div className="max-w-3xl space-y-4 text-base leading-relaxed text-[var(--fg2)]">

--- a/components/layout/Nav.tsx
+++ b/components/layout/Nav.tsx
@@ -3,10 +3,25 @@
 import { useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
+import { usePathname } from "next/navigation";
 import Button from "@/components/ui/Button";
+
+const navLinks = [
+  { href: "/services", label: "Services" },
+  { href: "/work", label: "How We Work" },
+  { href: "/about", label: "About" },
+];
 
 export default function Nav() {
   const [menuOpen, setMenuOpen] = useState(false);
+  const pathname = usePathname();
+
+  const linkClass = (href: string) =>
+    `text-sm font-medium transition-colors ${
+      pathname === href
+        ? "amp-bolt-bar text-white"
+        : "text-white/72 hover:text-white"
+    }`;
 
   return (
     <header className="sticky top-0 z-50 border-b border-white/10 bg-amp-ink/80 text-white backdrop-blur-xl">
@@ -24,24 +39,16 @@ export default function Nav() {
           </Link>
 
           <nav className="hidden items-center gap-8 md:flex">
-            <Link
-              href="/services"
-              className="text-sm font-medium text-white/72 transition-colors hover:text-white"
-            >
-              Services
-            </Link>
-            <Link
-              href="/work"
-              className="text-sm font-medium text-white/72 transition-colors hover:text-white"
-            >
-              How We Work
-            </Link>
-            <Link
-              href="/about"
-              className="text-sm font-medium text-white/72 transition-colors hover:text-white"
-            >
-              About
-            </Link>
+            {navLinks.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                aria-current={pathname === link.href ? "page" : undefined}
+                className={linkClass(link.href)}
+              >
+                {link.label}
+              </Link>
+            ))}
             <Button
               href="/contact"
               variant="primary"
@@ -73,27 +80,17 @@ export default function Nav() {
         {menuOpen && (
           <div className="border-t border-white/10 py-6 md:hidden">
             <nav className="flex flex-col gap-5">
-              <Link
-                href="/services"
-                className="text-sm font-medium text-white/72"
-                onClick={() => setMenuOpen(false)}
-              >
-                Services
-              </Link>
-              <Link
-                href="/work"
-                className="text-sm font-medium text-white/72"
-                onClick={() => setMenuOpen(false)}
-              >
-                How We Work
-              </Link>
-              <Link
-                href="/about"
-                className="text-sm font-medium text-white/72"
-                onClick={() => setMenuOpen(false)}
-              >
-                About
-              </Link>
+              {navLinks.map((link) => (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  aria-current={pathname === link.href ? "page" : undefined}
+                  className={linkClass(link.href)}
+                  onClick={() => setMenuOpen(false)}
+                >
+                  {link.label}
+                </Link>
+              ))}
               <div>
                 <Button
                   href="/contact"

--- a/components/sections/ClosingCTA.tsx
+++ b/components/sections/ClosingCTA.tsx
@@ -14,7 +14,7 @@ export default function ClosingCTA() {
           transition={{ duration: 0.6, ease: "easeOut" }}
           className="max-w-4xl"
         >
-          <p className="mb-6 text-sm font-semibold uppercase tracking-[0.24em] text-amp-red/80">
+          <p className="amp-eyebrow mb-6">
             Ready To Build
           </p>
           <h2 className="display-type mb-6 text-[3.7rem] leading-[0.92] text-white sm:text-[5rem] md:text-[6.4rem]">

--- a/components/sections/Guide.tsx
+++ b/components/sections/Guide.tsx
@@ -31,7 +31,7 @@ export default function Guide() {
         viewport={{ once: true }}
         transition={{ duration: 0.6, ease: "easeOut" }}
       >
-        <p className="mb-4 text-sm font-semibold uppercase tracking-[0.24em] text-amp-red">
+        <p className="amp-eyebrow mb-4">
           Why AmpTech
         </p>
 
@@ -68,7 +68,7 @@ export default function Guide() {
               transition={{ duration: 0.5, delay: i * 0.08, ease: "easeOut" }}
               className="section-rule pt-5"
             >
-              <p className="mb-3 text-sm font-semibold uppercase tracking-[0.2em] text-amp-red">
+              <p className="amp-eyebrow mb-3">
                 {feature.title}
               </p>
               <p className="text-base leading-relaxed text-[var(--fg2)]">

--- a/components/sections/Plan.tsx
+++ b/components/sections/Plan.tsx
@@ -30,7 +30,7 @@ export default function Plan() {
         viewport={{ once: true }}
         transition={{ duration: 0.6, ease: "easeOut" }}
       >
-        <p className="mb-4 text-sm font-semibold uppercase tracking-[0.24em] text-amp-red/80">
+        <p className="amp-eyebrow mb-4">
           The Plan
         </p>
         <h2 className="display-type mb-14 max-w-4xl text-[3.3rem] leading-[0.92] text-white sm:text-[4.4rem] md:text-[5.4rem]">

--- a/components/sections/Problem.tsx
+++ b/components/sections/Problem.tsx
@@ -12,7 +12,7 @@ export default function Problem() {
           viewport={{ once: true }}
           transition={{ duration: 0.6, ease: "easeOut" }}
         >
-          <p className="mb-8 text-sm font-semibold uppercase tracking-[0.24em] text-amp-red">
+          <p className="amp-eyebrow mb-8">
             The Problem
           </p>
 

--- a/components/sections/SocialProof.tsx
+++ b/components/sections/SocialProof.tsx
@@ -1,11 +1,15 @@
 "use client";
 
+import type { ReactNode } from "react";
 import { motion } from "framer-motion";
 import SectionWrapper from "@/components/ui/SectionWrapper";
 import Button from "@/components/ui/Button";
 
-const proofPoints = [
-  "20+ years building software beyond the prototype stage",
+const proofPoints: ReactNode[] = [
+  <>
+    <span className="amp-metric">20+ years</span> building software beyond the
+    prototype stage
+  </>,
   "References from people who have worked with us directly",
   "A scoping process that tells you what is real before you commit",
 ];
@@ -21,7 +25,7 @@ export default function SocialProof() {
       >
         <div className="flex flex-col gap-10 md:flex-row md:items-center md:justify-between">
           <div className="max-w-xl">
-            <p className="mb-4 text-sm font-semibold uppercase tracking-[0.24em] text-amp-red">
+            <p className="amp-eyebrow mb-4">
               Confidence
             </p>
             <h2 className="display-type mb-4 text-[3rem] leading-[0.92] text-amp-ink sm:text-[3.9rem] md:text-[4.6rem]">
@@ -33,8 +37,8 @@ export default function SocialProof() {
               of work we can carry across the finish line.
             </p>
             <div className="mt-10 space-y-5 border-t border-black/10 pt-6">
-              {proofPoints.map((point) => (
-                <div key={point} className="flex items-start gap-3">
+              {proofPoints.map((point, i) => (
+                <div key={i} className="flex items-start gap-3">
                   <span className="mt-2 h-2 w-2 flex-shrink-0 rounded-full bg-amp-red" />
                   <p className="text-base leading-relaxed text-[var(--fg2)]">
                     {point}

--- a/components/sections/Success.tsx
+++ b/components/sections/Success.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { motion } from "framer-motion";
+import { Check } from "lucide-react";
 import SectionWrapper from "@/components/ui/SectionWrapper";
 
 const outcomes = [
@@ -22,27 +23,6 @@ const outcomes = [
   },
 ];
 
-function CheckIcon() {
-  return (
-    <svg
-      width="16"
-      height="16"
-      viewBox="0 0 16 16"
-      fill="none"
-      aria-hidden="true"
-      className="flex-shrink-0 text-amp-red"
-    >
-      <path
-        d="M2.5 8.5l3.5 3.5 7.5-8"
-        stroke="currentColor"
-        strokeWidth="2.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
 export default function Success() {
   return (
     <SectionWrapper>
@@ -52,7 +32,7 @@ export default function Success() {
         viewport={{ once: true }}
         transition={{ duration: 0.6, ease: "easeOut" }}
       >
-        <p className="mb-4 text-sm font-semibold uppercase tracking-[0.24em] text-amp-red">
+        <p className="amp-eyebrow mb-4">
           Success
         </p>
         <h2 className="display-type mb-14 max-w-4xl text-[3.3rem] leading-[0.92] text-amp-ink sm:text-[4.3rem] md:text-[5.2rem]">
@@ -75,8 +55,8 @@ export default function Success() {
               transition={{ duration: 0.5, delay: i * 0.1, ease: "easeOut" }}
               className="flex items-start gap-4"
             >
-              <div className="mt-0.5 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full bg-amp-red/10">
-                <CheckIcon />
+              <div className="mt-0.5 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg bg-amp-red/10">
+                <Check size={16} strokeWidth={2.5} className="flex-shrink-0 text-amp-red" aria-hidden />
               </div>
               <div>
                 <h3 className="mb-1 text-lg font-bold leading-snug text-amp-ink">

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -13,7 +13,7 @@ const variantClasses: Record<Variant, string> = {
 };
 
 const base =
-  "inline-flex cursor-pointer items-center justify-center rounded-md px-6 py-3 text-sm font-semibold uppercase tracking-[0.16em] transition-all duration-200";
+  "inline-flex cursor-pointer items-center justify-center rounded-md px-6 py-3 text-sm font-semibold tracking-[0.01em] transition-all duration-200";
 
 type LinkButtonProps = {
   variant?: Variant;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "amptech-site",
-  "version": "1.0.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amptech-site",
-      "version": "1.0.0",
+      "version": "1.5.0",
       "dependencies": {
         "framer-motion": "^12",
+        "lucide-react": "^1.21.0",
         "next": "16.1.6",
         "react": "19.2.3",
         "react-dom": "19.2.3",
@@ -7070,6 +7071,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.21.0.tgz",
+      "integrity": "sha512-reEZMXq8Qdd5jg5XYkQ5TR1fB/GiQ7ih4vcrthYDtgjSDwh0i6/YLiGjsWsIwgN49gpAnd4J2elSNzncMEEUUQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "framer-motion": "^12",
+    "lucide-react": "^1.21.0",
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3",


### PR DESCRIPTION
## Closes #28

## Summary
Phase 3 of the amptech-design migration (epic #24) — the structural/visual brand pass. Tokens + fonts landed in #26/#27; this applies the signature elements and finishes the sweep.

- **Eyebrows → `.amp-eyebrow`** signature (red bar + tracked label) across all section kickers and card labels
- **Active nav item → `.amp-bolt-bar`** via `usePathname` (+ `aria-current="page"`)
- **`.amp-metric`** (JetBrains Mono) on the "20+ years" stats (SocialProof, about, work)
- **Lucide icons** — replaced the two inline check SVGs with `lucide-react` `<Check>` (Success, contact); added the dependency
- **Button** — dropped the `uppercase` transform (sentence-case per brand)
- Icon-badge circles → `rounded-lg` (angular); reworded a globals.css comment that mentioned Bebas

## Spec Checklist
- [x] Sections + subpages on amptech tokens with signature elements
- [x] Sweep greps pass: `rounded-full` → only tiny bullet dots + Badge pill (no buttons/cards); `linear-gradient` → only `--grad-ink`/grid; hex in `components/` → 0
- [x] Numbers render in mono via `.amp-metric`
- [x] DoD grep `Montserrat|Bebas|brand-cream|brand-night|brand-steel` → 0
- [x] **Visual pass at desktop + mobile** (preview server, screenshots + computed-style inspection)

## Verification
- `tsc` clean · `npm run build` clean · DoD greps → 0
- Browser-verified: `.amp-eyebrow` red bar renders; active nav link computes `padding-left:14px` + `aria-current=page`; `.amp-metric` = JetBrains Mono 500; `svg.lucide-check` = 16px amp-red; **no console errors**; mobile (375px) hero + buttons correct

## Scope note (handed to #19)
Headline and button/nav **label wording + casing** stay with #19 (copy). This PR removed the uppercase *transform* and applied `.amp-eyebrow` *styling*; #19 supplies the sentence-case words. The ALL-CAPS headlines visible in screenshots are expected until #19.

## After this
Epic #24 (design migration) is complete. Remaining: #19 (StoryBrand copy), after which `claude-code-handoff/` gets its final cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
