### PR TITLE
feat: StoryBrand copy rewrite + human voice

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -16,21 +16,21 @@ export default function AboutPage() {
           About
         </p>
         <h1 className="display-type text-[3.5rem] leading-[0.92] text-amp-ink mb-6 sm:text-[4.7rem] md:text-[5.8rem]">
-          THE HELP
+          The help
           <br />
-          BEHIND THE
+          behind the
           <br />
-          BUILD.
+          build.
         </h1>
         <p className="text-lg text-[var(--fg2)] leading-relaxed mb-6">
           AmpTech was founded for the moment when a promising build stops
           moving. The demo exists. The idea is still strong. But the project
-          needs experienced engineering to become something real users can rely
-          on.
+          needs experienced engineering to become something people can actually
+          rely on.
         </p>
         <p className="text-base text-[var(--fg2)] leading-relaxed mb-6">
           We work with founders and business owners who have momentum, clarity,
-          and a real product vision, but need help getting from rough version to
+          and a clear product vision, but need help getting from rough build to
           launch-ready software.
         </p>
         <p className="text-base text-[var(--fg2)] leading-relaxed mb-10">
@@ -45,18 +45,18 @@ export default function AboutPage() {
           <p className="text-base text-[var(--fg2)] leading-relaxed mb-4">
             <span className="amp-metric">20+ years</span> of professional
             software development experience, direct communication, transparent
-            scoping, and references from people who have worked with us directly.
+            scoping, and references from people we&apos;ve worked with directly.
           </p>
           <p className="text-base text-[var(--fg2)] leading-relaxed">
-            The goal is simple: help you get from stuck build to real software
-            without having to become a developer yourself.
+            The goal is simple: help you get from a stuck build to working
+            software without having to become a developer yourself.
           </p>
         </div>
         <div className="flex flex-wrap gap-3 mb-10">
           <Badge>20+ Years Engineering Experience</Badge>
           <Badge>AI-Assisted Development</Badge>
           <Badge>Transparent Scoping</Badge>
-          <Badge>You Own Everything</Badge>
+          <Badge>Direct Communication</Badge>
         </div>
         <Button href="/contact" variant="primary">
           Book A Discovery Call

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -23,7 +23,7 @@ const jetbrainsMono = JetBrains_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "AmpTech — From Stuck Demo To Real Product",
+  title: "AmpTech — From Stuck Demo to Shipped Product",
   description:
     "AmpTech helps founders and business owners turn rough prototypes, stalled AI builds, and app ideas into software people can actually use.",
 };

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -4,7 +4,7 @@ import Button from "@/components/ui/Button";
 export const metadata = {
   title: "Services — AmpTech",
   description:
-    "How AmpTech turns rough prototypes, stalled builds, and app ideas into software people can use.",
+    "How AmpTech turns a stalled AI build into software that holds up in production.",
 };
 
 const serviceAreas = [
@@ -34,16 +34,15 @@ export default function ServicesPage() {
           Services
         </p>
         <h1 className="display-type max-w-4xl text-[3.5rem] leading-[0.92] text-amp-ink sm:text-[4.7rem] md:text-[5.8rem]">
-          FROM STUCK
+          From stuck
           <br />
-          TO SHIPPED,
+          to shipped,
           <br />
-          DONE RIGHT.
+          done right.
         </h1>
         <p className="mt-6 max-w-3xl text-lg leading-relaxed text-[var(--fg2)]">
-          AmpTech helps founders and business owners turn rough prototypes,
-          stalled AI builds, and app ideas into software that holds up under
-          real use.
+          You&apos;ve got a prototype that demos well but isn&apos;t ready for
+          production. We take it the rest of the way — and hand it over.
         </p>
 
         <div className="mt-16 grid gap-5 border-t border-black/10 pt-8 md:grid-cols-2">
@@ -66,14 +65,14 @@ export default function ServicesPage() {
           <div className="max-w-3xl space-y-4 text-base leading-relaxed text-[var(--fg2)]">
             <p>
               Every engagement starts with a discovery call. If the build is a
-              fit, the next step is scoped planning so you know what can be
-              kept, what needs work, how long it should take, and what it will
+              fit, the next step is scoped planning, so you know what can be
+              kept, what needs work, how long it should take, and what it&apos;ll
               cost before development begins.
             </p>
             <p>
-              AmpTech bills hourly against a scoped plan. The point is
-              visibility: you know what is happening before the work starts and
-              as it moves forward.
+              We bill hourly against a scoped plan. The point is visibility: you
+              know what&apos;s happening before the work starts and as it moves
+              forward.
             </p>
           </div>
         </div>

--- a/app/work/page.tsx
+++ b/app/work/page.tsx
@@ -12,14 +12,14 @@ const proofBlocks = [
     title: "Experience",
     body: (
       <>
-        <span className="amp-metric">20+ years</span> of professional software
-        development across real products, real users, and real delivery pressure.
+        <span className="amp-metric">20+ years</span> of building production
+        software that teams actually depend on.
       </>
     ),
   },
   {
     title: "References",
-    body: "We can provide references from people who have worked with us directly so you can hear how we operate from someone besides us.",
+    body: "We'll connect you with people we've actually worked with, so you hear how we operate from someone other than us.",
   },
 ];
 
@@ -31,18 +31,16 @@ export default function WorkPage() {
           How We Work
         </p>
         <h1 className="display-type max-w-4xl text-[3.5rem] leading-[0.92] text-amp-ink sm:text-[4.7rem] md:text-[5.8rem]">
-          HOW TO
+          How to tell if
           <br />
-          TELL IF
+          the build
           <br />
-          THE BUILD
-          <br />
-          CAN WORK.
+          can work.
         </h1>
         <p className="mt-6 max-w-3xl text-lg leading-relaxed text-[var(--fg2)]">
-          If you are deciding whether AmpTech is the right fit, start here. The
-          right partner should make the project clearer before they ask you to
-          commit to the build.
+          If you&apos;re deciding whether AmpTech is the right fit, start here. A
+          good partner makes the project clearer before asking you to commit to a
+          build.
         </p>
 
         <div className="mt-16 grid gap-5 border-t border-black/10 pt-8 md:grid-cols-2">
@@ -65,12 +63,12 @@ export default function WorkPage() {
           <div className="max-w-3xl space-y-4 text-base leading-relaxed text-[var(--fg2)]">
             <p>
               You should know what can be kept, what needs rebuilding, what the
-              tradeoffs are, and who is making the technical decisions before
+              tradeoffs are, and who&apos;s making the technical decisions before
               development begins.
             </p>
             <p>
-              You should leave with the code, the infrastructure, and the
-              documentation you need to keep moving after launch.
+              When it&apos;s done, you&apos;ll have everything you need to keep
+              moving — and no reason to call us unless you want to.
             </p>
           </div>
         </div>

--- a/components/layout/Footer.tsx
+++ b/components/layout/Footer.tsx
@@ -16,7 +16,7 @@ export default function Footer() {
               className="h-7 w-auto brightness-0 invert"
             />
             <p className="text-sm text-gray-400 mt-2">
-              From stuck prototype to real product.
+              From stuck prototype to production.
             </p>
           </div>
 

--- a/components/sections/ClosingCTA.tsx
+++ b/components/sections/ClosingCTA.tsx
@@ -15,20 +15,16 @@ export default function ClosingCTA() {
           className="max-w-4xl"
         >
           <p className="amp-eyebrow mb-6">
-            Ready To Build
+            Ready when you are
           </p>
           <h2 className="display-type mb-6 text-[3.7rem] leading-[0.92] text-white sm:text-[5rem] md:text-[6.4rem]">
-            READY TO
+            Ready to get this
             <br />
-            GET THIS
-            <br />
-            ACROSS
-            <br />
-            THE LINE?
+            across the line?
           </h2>
           <p className="mb-12 max-w-2xl text-lg leading-relaxed text-gray-300">
-            Bring the rough build, the stuck prototype, or the idea you cannot
-            stop thinking about. We will help you find the next real step.
+            Bring the stuck prototype, the rough build, or the idea you can&apos;t
+            stop thinking about. We&apos;ll help you find the next move.
           </p>
           <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center">
             <Button

--- a/components/sections/Guide.tsx
+++ b/components/sections/Guide.tsx
@@ -5,8 +5,8 @@ import SectionWrapper from "@/components/ui/SectionWrapper";
 
 const features = [
   {
-    title: "Find the real blockers",
-    description: "We separate surface bugs from architecture problems so the project stops moving in circles.",
+    title: "Find what's actually broken",
+    description: "We separate surface bugs from architecture problems, so the project stops going in circles.",
   },
   {
     title: "Build what has to hold",
@@ -32,28 +32,24 @@ export default function Guide() {
         transition={{ duration: 0.6, ease: "easeOut" }}
       >
         <p className="amp-eyebrow mb-4">
-          Why AmpTech
+          How we help
         </p>
 
         <div className="grid gap-12 border-t border-black/10 pt-10 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
           <div>
             <p className="display-type max-w-3xl text-[3.3rem] leading-[0.92] text-amp-ink sm:text-[4.4rem] md:text-[5.5rem]">
-              YOU NEED
+              You need someone
               <br />
-              SOMEONE WHO
+              who&apos;s shipped
               <br />
-              CAN GET IT
-              <br />
-              ACROSS
-              <br />
-              THE LINE.
+              this before.
             </p>
           </div>
           <div>
             <p className="text-lg leading-relaxed text-[var(--fg2)]">
-              AmpTech brings senior engineering judgment to the messy middle of
-              a build: the point where a prototype exists, but the product is
-              not stable enough to sell, demo, or depend on.
+              We bring senior engineering judgment to the messy middle — where a
+              prototype exists but isn&apos;t stable enough to sell, demo, or
+              depend on.
             </p>
           </div>
         </div>

--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -5,8 +5,8 @@ import Button from "@/components/ui/Button";
 
 const capabilityMarks = [
   "Stalled AI builds",
-  "Founder-led products",
-  "Launch-ready handoff",
+  "Prototype to production",
+  "Senior engineering",
 ];
 
 export default function Hero() {
@@ -41,13 +41,9 @@ export default function Hero() {
             transition={{ duration: 0.75, delay: 0.12, ease: "easeOut" }}
             className="display-type max-w-4xl text-[3.35rem] leading-[0.9] text-white sm:text-[6rem] md:text-[7.8rem] lg:text-[8.8rem]"
           >
-            YOU HAVE
+            You built the demo.
             <br />
-            A DEMO.
-            <br />
-            NOW BUILD
-            <br />
-            <span className="text-amp-red">THE PRODUCT.</span>
+            <span className="text-amp-red">We build the product.</span>
           </motion.h1>
 
           <motion.p
@@ -56,9 +52,9 @@ export default function Hero() {
             transition={{ duration: 0.6, delay: 0.22, ease: "easeOut" }}
             className="mt-6 max-w-2xl text-base leading-relaxed text-white/82 sm:text-lg"
           >
-            AmpTech helps founders and business owners turn promising AI builds,
-            rough prototypes, and half-finished app ideas into software people
-            can actually use.
+            You got a working prototype out of Replit, Bolt, Lovable, or Cursor.
+            We turn it into software that holds up when real users show up — and
+            hand you the keys.
           </motion.p>
 
           <motion.div
@@ -107,7 +103,7 @@ export default function Hero() {
           >
             <div className="w-full border-t border-white/18 pt-6">
               <p className="text-xs uppercase tracking-[0.24em] text-white/52">
-                You do not need another prompt. You need a build that holds up.
+                You don&apos;t need another prompt. You need a build that holds up.
               </p>
             </div>
           </motion.div>
@@ -132,8 +128,8 @@ export default function Hero() {
                   The hard part starts after the demo works.
                 </p>
                 <p className="mt-3 max-w-xs text-lg leading-relaxed text-white/78">
-                  We turn the rough version into the version you can show,
-                  launch, own, and keep improving.
+                  We turn the rough version into one you can launch, sell, and
+                  build on.
                 </p>
               </div>
             </div>

--- a/components/sections/Plan.tsx
+++ b/components/sections/Plan.tsx
@@ -7,17 +7,17 @@ const steps = [
   {
     number: "01",
     title: "Show us where it stands",
-    body: "Bring the idea, prototype, repo, screenshots, or rough build. We will meet you where the project is.",
+    body: "Bring the prototype, the repo, or the rough build. We'll meet you where the project actually is.",
   },
   {
     number: "02",
     title: "Get a clear build plan",
-    body: "We identify what can be kept, what needs rebuilding, what it will take, and what should happen first.",
+    body: "We tell you what's worth keeping, what needs rebuilding, what it'll take, and what to do first.",
   },
   {
     number: "03",
-    title: "Launch with ownership",
-    body: "You get working software, deployment support, documentation, and the code in your hands.",
+    title: "Go live",
+    body: "You ship working software with deployment support and documentation, and a codebase you can keep building on.",
   },
 ];
 
@@ -31,14 +31,14 @@ export default function Plan() {
         transition={{ duration: 0.6, ease: "easeOut" }}
       >
         <p className="amp-eyebrow mb-4">
-          The Plan
+          How it goes
         </p>
         <h2 className="display-type mb-14 max-w-4xl text-[3.3rem] leading-[0.92] text-white sm:text-[4.4rem] md:text-[5.4rem]">
-          A SIMPLE PATH
+          A simple path
           <br />
-          FROM STUCK
+          from stuck
           <br />
-          TO SHIPPED.
+          to shipped.
         </h2>
 
         <div className="grid gap-10 border-t border-white/14 pt-10 md:grid-cols-3 md:gap-8">

--- a/components/sections/Problem.tsx
+++ b/components/sections/Problem.tsx
@@ -13,35 +13,35 @@ export default function Problem() {
           transition={{ duration: 0.6, ease: "easeOut" }}
         >
           <p className="amp-eyebrow mb-8">
-            The Problem
+            Where builds stall
           </p>
 
           <div className="section-rule grid gap-12 pt-10 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)]">
             <div className="max-w-3xl">
               <p className="display-type text-[3.7rem] leading-[0.92] text-amp-ink sm:text-[5rem] md:text-[6.4rem]">
-                THE DEMO
+                The demo worked.
                 <br />
-                WORKED.
-                <br />
-                THEN REALITY
-                <br />
-                SHOWED UP.
+                Then reality showed up.
               </p>
             </div>
 
             <div className="space-y-6 pt-2">
               <p className="text-lg leading-relaxed text-[var(--fg2)]">
-                You got a screen on the page. Maybe a workflow clicked through.
-                Maybe it even felt like the product was almost there.
+                You got a screen on the page. A workflow clicked through. It
+                even felt like the product was almost there.
               </p>
               <p className="text-lg leading-relaxed text-[var(--fg2)]">
-                Then the hidden work started. Authentication broke. Data did
-                not save cleanly. Edge cases piled up. The AI kept changing the
-                same files and the project stopped getting closer to launch.
+                Then the hidden work showed up. Auth broke. Data didn&apos;t save
+                cleanly. Edge cases piled up. The AI kept rewriting the same
+                files, and every fix spawned two new bugs.
+              </p>
+              <p className="text-lg leading-relaxed text-[var(--fg2)]">
+                Now it&apos;s months in, and you honestly can&apos;t tell if
+                you&apos;re almost done or about to start over.
               </p>
               <p className="text-sm uppercase tracking-[0.24em] text-amp-steel">
-                The gap between promising and launch-ready is where most builds
-                stall.
+                Left alone, that&apos;s how promising builds die — quietly, in a
+                repo no one opens again.
               </p>
             </div>
           </div>

--- a/components/sections/SocialProof.tsx
+++ b/components/sections/SocialProof.tsx
@@ -10,8 +10,8 @@ const proofPoints: ReactNode[] = [
     <span className="amp-metric">20+ years</span> building software beyond the
     prototype stage
   </>,
-  "References from people who have worked with us directly",
-  "A scoping process that tells you what is real before you commit",
+  "References from people we've actually worked with",
+  "A scoping process that shows you what's worth keeping before you commit",
 ];
 
 export default function SocialProof() {
@@ -26,15 +26,15 @@ export default function SocialProof() {
         <div className="flex flex-col gap-10 md:flex-row md:items-center md:justify-between">
           <div className="max-w-xl">
             <p className="amp-eyebrow mb-4">
-              Confidence
+              Before you commit
             </p>
             <h2 className="display-type mb-4 text-[3rem] leading-[0.92] text-amp-ink sm:text-[3.9rem] md:text-[4.6rem]">
               Look before you book.
             </h2>
             <p className="text-lg leading-relaxed text-[var(--fg2)]">
-              You should not have to trust a big claim on a small website. You
-              should be able to see how we think, how we scope, and what kind
-              of work we can carry across the finish line.
+              You shouldn&apos;t have to trust a big claim on a small website.
+              You should be able to see how we think, how we scope, and the kind
+              of work we take to launch.
             </p>
             <div className="mt-10 space-y-5 border-t border-black/10 pt-6">
               {proofPoints.map((point, i) => (

--- a/components/sections/Success.tsx
+++ b/components/sections/Success.tsx
@@ -6,20 +6,20 @@ import SectionWrapper from "@/components/ui/SectionWrapper";
 
 const outcomes = [
   {
-    headline: "A product you can put in front of people.",
-    body: "Not a demo that only works when everything goes exactly right.",
+    headline: "You can put it in front of anyone.",
+    body: "Investors, customers, your board — not a happy-path demo that only works when everything goes right.",
   },
   {
-    headline: "A build that stops drifting.",
+    headline: "You stop going in circles.",
     body: "Clear priorities, fewer loops, and progress you can actually measure.",
   },
   {
-    headline: "Ownership without a trap door.",
-    body: "The code is yours. The infrastructure is yours. The direction is clear.",
+    headline: "You can finally sell it.",
+    body: "It holds up under load and edge cases, not just the path you click through in a demo.",
   },
   {
-    headline: "Something you can keep improving.",
-    body: "Documented, handed over cleanly, and built to move after launch.",
+    headline: "You can keep building without us.",
+    body: "Documented and handed over cleanly, so your next developer picks up right where we left off.",
   },
 ];
 
@@ -33,16 +33,14 @@ export default function Success() {
         transition={{ duration: 0.6, ease: "easeOut" }}
       >
         <p className="amp-eyebrow mb-4">
-          Success
+          After we ship
         </p>
         <h2 className="display-type mb-14 max-w-4xl text-[3.3rem] leading-[0.92] text-amp-ink sm:text-[4.3rem] md:text-[5.2rem]">
-          WHAT CHANGES
+          What changes
           <br />
-          WHEN THE
+          once you
           <br />
-          PRODUCT IS
-          <br />
-          REAL.
+          can ship.
         </h2>
 
         <div className="grid gap-8 border-t border-black/10 pt-10 sm:grid-cols-2">

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,10 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // Vendored design-system skill assets (reference kit, not app source).
+    // Flat config doesn't auto-ignore dot-dirs, so these need to be explicit.
+    ".agents/**",
+    ".claude/**",
   ]),
 ]);
 


### PR DESCRIPTION
## Closes #19

## Summary
The StoryBrand copy rewrite that kicked off this whole effort. Makes the founder the hero and AmpTech the guide, names the situation (and the fear) in a human voice, and strips the AI-generated tells.

**Framing**
- Hero reassigns the work to the guide: **"You built the demo. We build the product."** (sentence case) — also the brand one-liner
- Subtext names the villain: **Replit, Bolt, Lovable, or Cursor**
- Problem section gains the **internal-problem line** (sunk cost + doubt: "Now it's months in, and you honestly can't tell if you're almost done or about to start over.") and the **single failure-stakes line** ("Left alone, that's how promising builds die…")
- Success outcomes describe the **founder's transformation** ("You can put it in front of anyone", "You can finally sell it"), not the artifact's state — and the muddled "trap door" metaphor is gone

**Voice (site-wide: homepage + /services + /work + /about)**
- All headlines **sentence case** (per the #28 hand-off); ALL-CAPS only on eyebrows/metadata
- Contractions throughout
- **"real/reality" 11 → 2**; **"across the line" 3 → 1** (kept only on the closing CTA)
- **Ownership stated once**, strongly (the Guide "Hand it over cleanly" card) — removed from Plan, Success, About badge, Work
- Section eyebrows carry content ("Where builds stall", "How we help", "How it goes") instead of StoryBrand worksheet names
- Duplicate rule-of-three lists trimmed; the "prototype/stalled build/idea" list appears once

## Spec Checklist
- [x] All **Rules** implemented (framing, voice, structure, guardrails)
- [x] **Examples** verified in-browser (hero reassigns work; villain named; internal problem present; contractions; `real` ≤ 3)
- [x] All **Questions** resolved at grooming
- [x] Stays in scope — **copy only**, no layout/design changes; Umami events + single primary CTA preserved

## Verification
- `tsc` clean · `npm run lint` clean · `npm run build` clean
- Greps: `real/reality` → 2 · `across the line` → 1 · ownership claim → 1 (Guide)
- Browser-verified desktop + mobile: hero headline fits at both sizes (no overflow), Problem internal-problem + stakes render, eyebrows show content labels, **no console errors**

## Incidental fix (disclosed)
Second commit fixes a **pre-existing** broken lint gate: ESLint flat config wasn't ignoring dot-dirs, so it was linting the vendored amptech-design kit under `.agents/`/`.claude/` (50 errors since #25). Added those to `globalIgnores`. Not copy-related, but it unblocked the lint gate for this PR.

## After this
- `claude-code-handoff/` (still untracked) can be removed as final cleanup
- Optional follow-ups remain in the backlog: #9 (case study / restore "proof" language), #21 (contact page), #22 (transitional CTA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
