### PR TITLE
fix: scale down hero headline so it fits the viewport

### DIFF
--- a/components/sections/Hero.tsx
+++ b/components/sections/Hero.tsx
@@ -39,7 +39,7 @@ export default function Hero() {
             initial={false}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.75, delay: 0.12, ease: "easeOut" }}
-            className="display-type max-w-4xl text-[3.35rem] leading-[0.9] text-white sm:text-[6rem] md:text-[7.8rem] lg:text-[8.8rem]"
+            className="display-type max-w-4xl text-[3.1rem] leading-[0.95] text-white sm:text-[4.5rem] md:text-[5.5rem] lg:text-[6.5rem]"
           >
             You built the demo.
             <br />


### PR DESCRIPTION
## Closes #33

## Summary
Fixes the hero headline overflowing the viewport at desktop width — the regression you caught at localhost:3000.

The `lg:text-[8.8rem]` (140px) size was tuned for the old four short ALL-CAPS lines. #19's sentence-case copy ("You built the demo. We build the product.") has longer words that wrapped to **5 lines / 634px** at desktop, growing the hero to **1171px** and pushing the subtext, CTAs, and the word "product." below the fold.

Reduced the responsive sizes: `3.35→3.1rem`, `sm 6→4.5rem`, `md 7.8→5.5rem`, `lg 8.8→6.5rem` (leading `0.9→0.95` for sentence-case rhythm).

## Verification (at true desktop width this time)
Measured in-browser via the preview server at the breakpoint that was broken:
- **1440×900**: headline now 104px, **4 lines**, primary CTA bottom at 801px (above the fold), hero ~932px ≈ one viewport (was 1171px)
- **375px**: 49.6px, 4 lines, fits the 343px column, CTA visible

## Root-cause note
My #19 verification screenshots were captured at ~800px width, so the `lg:` size never got eyes on it. I've confirmed the fix at 1440px and mobile directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
